### PR TITLE
Feat/ea quadrorp

### DIFF
--- a/pkg/commands/gm/criarquadrorp.src
+++ b/pkg/commands/gm/criarquadrorp.src
@@ -1,0 +1,148 @@
+use uo;
+use os;
+use cfgfile;
+
+include ":gumps:gumps";
+include ":gumps:gumps_ex";
+include ":gumps:htmlGump";
+
+const GUMP_WIDTH := 520;
+const GUMP_HEIGHT := 380;
+const GUMP_BACKGROUND := 39929;
+const INTERNAL_BACKGROUND := 9350;
+const INTERNAL_WIDTH := 435;
+const VERTICAL_SPACING := 20;
+const BACKGROUND_WIDTH := 465;
+const BACKGROUND_HEIGHT := 280;
+
+program criarquadrorp(who, text)
+    if (!who.cmdlevel)
+        SendSysMessage(who, "Esse comando é apenas para GMs.");
+        return 0;
+    endif
+
+    SendSysMessage(who, "Selecione o item ao qual deseja adicionar uma imagem.");
+    var alvo := Target(who, TGTOPT_CHECK_LOS);
+    if (!alvo)
+        SendSysMessage(who, "Cancelado");
+        return 0;
+    endif
+
+    if (!alvo.IsA(POLCLASS_ITEM))
+        SendSysMessage(who, "Você só pode selecionar itens.");
+        return 0;
+    endif
+
+    if (alvo.IsA(POLCLASS_CONTAINER))
+        SendSysMessage(who, "Você não pode adicionar uma imagem a um container.");
+        return 0;
+    endif
+
+    if (ItemHasSpecialProperties(alvo))
+        SendSysMessage(who, "Este item já possui propriedades especiais e não pode receber uma imagem.");
+        return 0;
+    endif
+
+    var gump_data := CreateConfigurationGump();
+    var input := GFSendGump(who, gump_data.gump);
+
+    if (input[0] == 1) // OK button
+        var title := GFExtractData(input, gump_data.txt1);
+        var url := GFExtractData(input, gump_data.txt2);
+
+        SetObjProperty(alvo, "ImageItem", 1);
+        SetObjProperty(alvo, "title", title);
+        SetObjProperty(alvo, "url", url);
+        SetObjProperty(alvo, "crafterserial", who.serial);
+        
+        alvo.usescript := ":custompizza:criarquadrorp/useimage";
+
+        SendSysMessage(who, "O item foi configurado com sucesso para exibir uma imagem.");
+    else
+        SendSysMessage(who, "Cancelado");
+    endif
+endprogram
+
+function ItemHasSpecialProperties(item)
+    var itemdesc := ReadConfigFile(":*:itemdesc");
+    var elem := FindConfigElem(itemdesc, item.objtype);
+    
+    if (elem)
+        if (elem.ControlScript || 
+            elem.CreateScript || 
+            elem.DestroyScript || 
+            elem.Script || 
+            elem.DoubleclickRange || 
+            elem.MethodScript || 
+            elem.CanInsertScript || 
+            elem.OnInsertScript || 
+            elem.CanRemoveScript || 
+            elem.OnRemoveScript)
+            return 1;
+        endif
+    endif
+
+    if (item.usescript)
+        return 1;
+    endif
+
+    return 0;
+endfunction
+
+
+function CreateConfigurationGump()
+    var gump := GFCreateGump();
+    GFClosable(gump, 1);
+    GFDisposable(gump, 0);
+    
+    var gump_width := 500;  // Diminuído de 520 para 500
+    var gump_height := 380;
+    var content_width := 475;  // Ajustado de acordo com a nova largura do gump
+    
+    GFGumpPicTiled(gump, 0, 0, gump_width, gump_height, GUMP_BACKGROUND);
+    AdicionarMoldura(gump, gump_width, gump_height);
+
+    GFTextMid(gump, 25, 22, gump_width - 50, 53, "Configuração da Imagem");
+
+    var y_pos := 60;
+    GFResizePic(gump, 15, y_pos, INTERNAL_BACKGROUND, content_width, BACKGROUND_HEIGHT);
+    y_pos += 20;
+
+    GFTextLine(gump, 30, y_pos, 53, "Título:");
+    var txt1 := GFTextEntry(gump, 30, y_pos + 20, content_width - 10, 20, 0, "");
+    y_pos += 50;
+
+    GFTextLine(gump, 30, y_pos, 53, "URL:");
+    var txt2 := GFTextEntry(gump, 30, y_pos + 20, content_width - 10, 20, 0, "");
+    y_pos += 50;
+
+    GFTextLine(gump, 30, y_pos, 2100, "Tamanho máximo da imagem: 800x800 pixels");
+    y_pos += 40;
+
+    GFAddButton(gump, (gump_width / 2) - 15, y_pos, 247, 248, GF_CLOSE_BTN, 1);
+
+    var gump_data := struct{
+        "gump" := gump,
+        "txt1" := txt1,
+        "txt2" := txt2
+    };
+    
+    return gump_data;
+endfunction
+
+function AdicionarMoldura(byref gump, width, height)
+    var molduras := array{
+        struct{ x := 0, y := 0, width := 25, height := 25, gump := 39925 },
+        struct{ x := width - 25, y := 0, width := 35, height := 25, gump := 39927 },
+        struct{ x := 25, y := 0, width := width - 41, height := 25, gump := 39926 },
+        struct{ x := 25, y := height - 25, width := width - 25, height := 35, gump := 39932 },
+        struct{ x := 0, y := 25, width := 10, height := height - 50, gump := 39928 },
+        struct{ x := width - 25, y := 25, width := 35, height := height - 50, gump := 39930 },
+        struct{ x := width - 25, y := height - 25, width := 35, height := 35, gump := 39933 },
+        struct{ x := 0, y := height - 25, width := 35, height := 35, gump := 39931 }
+    };
+
+    foreach moldura in molduras
+        GFGumpPicTiled(gump, moldura.x, moldura.y, moldura.width, moldura.height, moldura.gump);
+    endforeach
+endfunction

--- a/pkg/commands/gm/criarquadrorp.src
+++ b/pkg/commands/gm/criarquadrorp.src
@@ -1,3 +1,4 @@
+//1
 use uo;
 use os;
 use cfgfile;

--- a/pkg/items/custompizza/criarquadrorp/useimage.src
+++ b/pkg/items/custompizza/criarquadrorp/useimage.src
@@ -38,13 +38,10 @@ function ShowImageGump(who, title, url)
     GFGumpPicTiled(gump, 0, 0, 850, 900, GUMP_BACKGROUND);
     AdicionarMoldura(gump, 850, 900);
 
-    // Adicionando um fundo para o título
     GFResizePic(gump, 30, 845, INTERNAL_BACKGROUND, 800, 30);
     
-    // Usando o título corretamente
     GFTextMid(gump, 20, 852, 800, 53, title);
 
-    // Usando a URL corretamente
     GFHTMLArea(gump, 30, 30, 800, 800, "<img src=\"" + url + "\" width=\"800\" height=\"800\" x=\"0\" y=\"0\">");
 
     GFSendGump(who, gump);
@@ -55,9 +52,9 @@ function ShowEditGump(who, self)
     GFClosable(gump, 1);
     GFDisposable(gump, 0);
     
-    var gump_width := 435;  // Aumentado de 400 para 415
+    var gump_width := 435;
     var gump_height := 300;
-    var content_width := 415;  // Aumentado de 380 para 395
+    var content_width := 415;
     
     GFGumpPicTiled(gump, 0, 0, gump_width, gump_height, GUMP_BACKGROUND);
     AdicionarMoldura(gump, gump_width, gump_height);
@@ -105,45 +102,18 @@ function AdicionarMoldura(byref gump, width, height)
     endforeach
 endfunction
 
-
 function GetSoundAndEmote(graphic)
-    var resultado := array{0, ""};
-    
-    case(graphic)
-        401:
-            resultado[1] := 0x32C;
-            resultado[2] := "*Oooh*";
-        400:
+    var resultado := array{};
+    if (graphic == 0x190 || graphic == 0x191)  // Humanos
+        if (graphic == 0x190)  // Masculino
             resultado[1] := 0x43E;
-            resultado[2] := "*Oooh*";
-        1828:
-            resultado[1] := 0x43E;
-            resultado[2] := "*Oooh*";
-        1829:
+        else  // Feminino
             resultado[1] := 0x32C;
-            resultado[2] := "*Oooh*";
-        1830:
-            resultado[1] := 0x43E;
-            resultado[2] := "*Oooh*";
-        1831:
-            resultado[1] := 0x32C;
-            resultado[2] := "*Oooh*";
-        1832:
-            resultado[1] := 0x43E;
-            resultado[2] := "*Oooh*";
-        1833:
-            resultado[1] := 0x32C;
-            resultado[2] := "*Oooh*";
-        1834:
-            resultado[1] := 0x43E;
-            resultado[2] := "*Oooh*";
-        1835:
-            resultado[1] := 0x32C;
-            resultado[2] := "*Oooh*";
-        default:
-            resultado[1] := 0x32C;
-            resultado[2] := "*Oooh*";
-    endcase
-    
+        endif
+        resultado[2] := "Oooh";
+    else  // Para outros tipos de corpos, você pode adicionar mais condições aqui
+        resultado[1] := 0x43E;  // Som padrão
+        resultado[2] := "Hmm";  // Emote padrão
+    endif
     return resultado;
 endfunction

--- a/pkg/items/custompizza/criarquadrorp/useimage.src
+++ b/pkg/items/custompizza/criarquadrorp/useimage.src
@@ -1,0 +1,149 @@
+use uo;
+use os;
+use cfgfile;
+use attributes;
+
+include ":datafile:datafile";
+include ":gumps:gumps";
+include ":gumps:gumps_ex";
+include ":gumps:htmlGump";
+include ":fls_core:packets";
+
+const GUMP_BACKGROUND := 39929;
+const INTERNAL_BACKGROUND := 9350;
+
+program useimage(who, self)
+    var title := GetObjProperty(self, "title");
+    var url := GetObjProperty(self, "url");
+    
+    if(who.serial != GetObjProperty(self, "crafterserial"))
+        var soundAndEmote := GetSoundAndEmote(who.graphic);
+        
+        PrintTextAbove(who, "*Observando detalhadamente*");
+        Sleep(2);
+        PlaySoundEffect(who, soundAndEmote[1]);
+        PrintTextAbove(who, soundAndEmote[2]);
+        
+        ShowImageGump(who, title, url);
+    else
+        ShowEditGump(who, self);
+    endif
+endprogram
+
+function ShowImageGump(who, title, url)
+    var gump := GFCreateGump();
+    GFClosable(gump, 1);
+    GFDisposable(gump, 0);
+    
+    GFGumpPicTiled(gump, 0, 0, 850, 900, GUMP_BACKGROUND);
+    AdicionarMoldura(gump, 850, 900);
+
+    // Adicionando um fundo para o título
+    GFResizePic(gump, 30, 845, INTERNAL_BACKGROUND, 800, 30);
+    
+    // Usando o título corretamente
+    GFTextMid(gump, 20, 852, 800, 53, title);
+
+    // Usando a URL corretamente
+    GFHTMLArea(gump, 30, 30, 800, 800, "<img src=\"" + url + "\" width=\"800\" height=\"800\" x=\"0\" y=\"0\">");
+
+    GFSendGump(who, gump);
+endfunction
+
+function ShowEditGump(who, self)
+    var gump := GFCreateGump();
+    GFClosable(gump, 1);
+    GFDisposable(gump, 0);
+    
+    var gump_width := 435;  // Aumentado de 400 para 415
+    var gump_height := 300;
+    var content_width := 415;  // Aumentado de 380 para 395
+    
+    GFGumpPicTiled(gump, 0, 0, gump_width, gump_height, GUMP_BACKGROUND);
+    AdicionarMoldura(gump, gump_width, gump_height);
+
+    GFResizePic(gump, 15, 10, INTERNAL_BACKGROUND, content_width, 280);
+    GFTextMid(gump, 10, 20, content_width, 53, "GUMP de edição do GM");
+
+    GFTextLine(gump, 20, 60, 53, "Título:");
+    var txt1 := GFTextEntry(gump, 20, 80, content_width - 40, 20, 0x00, GetObjProperty(self, "title"));
+
+    GFTextLine(gump, 20, 110, 53, "URL:");
+    var txt2 := GFTextEntry(gump, 20, 130, content_width - 40, 20, 0x00, GetObjProperty(self, "url"));
+
+    GFTextLine(gump, 20, 170, 2100, "Tamanho máximo da imagem: 800x800 pixels");
+
+    GFAddButton(gump, (gump_width / 2) - 15, 260, 247, 248, GF_CLOSE_BTN, 1);
+
+    var input := GFSendGump(who, gump);
+
+    if(input[1])
+        var new_title := GFExtractData(input, txt1);
+        var new_url := GFExtractData(input, txt2);
+        SetObjProperty(self, "title", new_title);
+        SetObjProperty(self, "url", new_url);
+
+        SendSysMessage(who, "Imagem atualizada com sucesso.");
+        ShowImageGump(who, new_title, new_url);
+    endif
+endfunction
+
+function AdicionarMoldura(byref gump, width, height)
+    var molduras := array{
+        struct{ x := 0, y := 0, width := 25, height := 25, gump := 39925 },
+        struct{ x := width - 25, y := 0, width := 35, height := 25, gump := 39927 },
+        struct{ x := 25, y := 0, width := width - 41, height := 25, gump := 39926 },
+        struct{ x := 25, y := height - 25, width := width - 25, height := 35, gump := 39932 },
+        struct{ x := 0, y := 25, width := 10, height := height - 50, gump := 39928 },
+        struct{ x := width - 25, y := 25, width := 35, height := height - 50, gump := 39930 },
+        struct{ x := width - 25, y := height - 25, width := 35, height := 35, gump := 39933 },
+        struct{ x := 0, y := height - 25, width := 35, height := 35, gump := 39931 }
+    };
+
+    foreach moldura in molduras
+        GFGumpPicTiled(gump, moldura.x, moldura.y, moldura.width, moldura.height, moldura.gump);
+    endforeach
+endfunction
+
+
+function GetSoundAndEmote(graphic)
+    var resultado := array{0, ""};
+    
+    case(graphic)
+        401:
+            resultado[1] := 0x32C;
+            resultado[2] := "*Oooh*";
+        400:
+            resultado[1] := 0x43E;
+            resultado[2] := "*Oooh*";
+        1828:
+            resultado[1] := 0x43E;
+            resultado[2] := "*Oooh*";
+        1829:
+            resultado[1] := 0x32C;
+            resultado[2] := "*Oooh*";
+        1830:
+            resultado[1] := 0x43E;
+            resultado[2] := "*Oooh*";
+        1831:
+            resultado[1] := 0x32C;
+            resultado[2] := "*Oooh*";
+        1832:
+            resultado[1] := 0x43E;
+            resultado[2] := "*Oooh*";
+        1833:
+            resultado[1] := 0x32C;
+            resultado[2] := "*Oooh*";
+        1834:
+            resultado[1] := 0x43E;
+            resultado[2] := "*Oooh*";
+        1835:
+            resultado[1] := 0x32C;
+            resultado[2] := "*Oooh*";
+        default:
+            resultado[1] := 0x32C;
+            resultado[2] := "*Oooh*";
+    endcase
+    
+    return resultado;
+endfunction

--- a/pkg/items/custompizza/criarquadrorp/useimage.src
+++ b/pkg/items/custompizza/criarquadrorp/useimage.src
@@ -1,3 +1,4 @@
+//1
 use uo;
 use os;
 use cfgfile;

--- a/pkg/items/quadros/itemdesc.cfg
+++ b/pkg/items/quadros/itemdesc.cfg
@@ -1,4 +1,4 @@
-//Quadros Pequenininhos (40 int)
+//1Quadros Pequenininhos (40 int)
 Item 0x4C60
 {
 name Quadro0

--- a/pkg/items/quadros/itemdesc.cfg
+++ b/pkg/items/quadros/itemdesc.cfg
@@ -7,7 +7,7 @@ graphic 0x4C60
 Cprop		canfix	i1
 int 40
 qtdtintas	3
-script usaquadro
+
 }
 Item 0x4C62
 {
@@ -17,7 +17,7 @@ graphic 0x4C62
 Cprop		canfix	i1
 int 40
 qtdtintas	3
-script usaquadro
+
 }
 Item 0x4C64
 {
@@ -27,7 +27,7 @@ graphic 0x4C64
 Cprop		canfix	i1
 int 40
 qtdtintas	3
-script usaquadro
+
 }
 Item 0x4C66
 {
@@ -37,7 +37,7 @@ graphic 0x4C66
 Cprop		canfix	i1
 int 40
 qtdtintas	3
-script usaquadro
+
 }
 Item 0x240D
 {
@@ -47,7 +47,7 @@ graphic 0x240D
 Cprop		canfix	i1
 int 40
 qtdtintas	3
-script usaquadro
+
 }
 Item 0x240F
 {
@@ -57,7 +57,7 @@ graphic 0x240F
 Cprop		canfix	i1
 int 40
 qtdtintas	3
-script usaquadro
+
 }
 Item 0x3F1D
 {
@@ -67,7 +67,7 @@ graphic 0x3F1D
 Cprop		canfix	i1
 int 40
 qtdtintas	2
-script usaquadro
+
 }
 Item 0x4C20
 {
@@ -77,7 +77,7 @@ graphic 0x4C20
 Cprop		canfix	i1
 int 50
 qtdtintas	4
-script usaquadro
+
 }
 Item 0xA2E8
 {
@@ -87,7 +87,7 @@ graphic 0xA2E8
 Cprop		canfix	i1
 int 50
 qtdtintas	4
-script usaquadro
+
 }
 Item 0xA2EA
 {
@@ -97,7 +97,7 @@ graphic 0xA2EA
 Cprop		canfix	i1
 int 50
 qtdtintas	4
-script usaquadro
+
 }
 Item 0xA2EC
 {
@@ -107,7 +107,7 @@ graphic 0xA2EC
 Cprop		canfix	i1
 int 50
 qtdtintas	4
-script usaquadro
+
 }
 Item 0xA2EE
 {
@@ -117,7 +117,7 @@ graphic 0xA2EE
 Cprop		canfix	i1
 int 50
 qtdtintas	4
-script usaquadro
+
 }
 Item 0xA2F0
 {
@@ -127,7 +127,7 @@ graphic 0xA2F0
 Cprop		canfix	i1
 int 50
 qtdtintas	4
-script usaquadro
+
 }
 Item 0xA2F2
 {
@@ -137,7 +137,7 @@ graphic 0xA2F2
 Cprop		canfix	i1
 int 50
 qtdtintas	4
-script usaquadro
+
 }
 //Ilustração (60)
 Item 0x9D53
@@ -148,7 +148,7 @@ graphic 0x9D53
 Cprop		canfix	i1
 int 60
 qtdtintas	3
-script usaquadro
+
 }
 Item 0x9D55
 {
@@ -158,7 +158,7 @@ graphic 0x9D55
 Cprop		canfix	i1
 int 60
 qtdtintas	3
-script usaquadro
+
 }
 Item 0x9D57
 {
@@ -168,7 +168,7 @@ graphic 0x9D57
 Cprop		canfix	i1
 int 60
 qtdtintas	3
-script usaquadro
+
 }
 Item 0x9D59
 {
@@ -178,7 +178,7 @@ graphic 0x9D59
 Cprop		canfix	i1
 int 60
 qtdtintas	3
-script usaquadro
+
 }
 Item 0x9D5B
 {
@@ -188,7 +188,7 @@ graphic 0x9D5B
 Cprop		canfix	i1
 int 60
 qtdtintas	3
-script usaquadro
+
 }
 Item 0x9D5D
 {
@@ -198,7 +198,7 @@ graphic 0x9D5D
 Cprop		canfix	i1
 int 60
 qtdtintas	3
-script usaquadro
+
 }
 Item 0x9E2D
 {
@@ -208,7 +208,7 @@ graphic 0x9E2D
 Cprop		canfix	i1
 int 60
 qtdtintas	3
-script usaquadro
+
 }
 Item 0x9E2F
 {
@@ -218,7 +218,7 @@ graphic 0x9E2F
 Cprop		canfix	i1
 int 60
 qtdtintas	3
-script usaquadro
+
 }
 Item 0x9E31
 {
@@ -228,7 +228,7 @@ graphic 0x9E31
 Cprop		canfix	i1
 int 60
 qtdtintas	3
-script usaquadro
+
 }
 Item 0x9E33
 {
@@ -238,7 +238,7 @@ graphic 0x9E33
 Cprop		canfix	i1
 int 60
 qtdtintas	3
-script usaquadro
+
 }
 Item 0xA242
 {
@@ -248,7 +248,7 @@ graphic 0xA242
 Cprop		canfix	i1
 int 60
 qtdtintas	3
-script usaquadro
+
 }
 Item 0xA244
 {
@@ -258,7 +258,7 @@ graphic 0xA244
 Cprop		canfix	i1
 int 60
 qtdtintas	3
-script usaquadro
+
 }
 Item 0xA246
 {
@@ -268,7 +268,7 @@ graphic 0xA246
 Cprop		canfix	i1
 int 60
 qtdtintas	3
-script usaquadro
+
 }
 Item 0xA248
 {
@@ -278,7 +278,7 @@ graphic 0xA248
 Cprop		canfix	i1
 int 60
 qtdtintas	3
-script usaquadro
+
 }
 //Retrato de pessoas (85 int)
 Item 0x0E9F
@@ -289,7 +289,7 @@ graphic 0x0E9F
 Cprop		canfix	i1
 int 85
 qtdtintas	4
-script usaquadro
+
 }
 Item 0x0EA1
 {
@@ -299,7 +299,7 @@ graphic 0x0EA1
 Cprop		canfix	i1
 int 85
 qtdtintas	4
-script usaquadro
+
 }
 Item 0x0EA6
 {
@@ -309,7 +309,7 @@ graphic 0x0EA6
 Cprop		canfix	i1
 int 85
 qtdtintas	4
-script usaquadro
+
 }
 Item 0x0EA7
 {
@@ -319,7 +319,7 @@ graphic 0x0EA7
 Cprop		canfix	i1
 int 85
 qtdtintas	4
-script usaquadro
+
 }
 Item 0xA1E0
 {
@@ -329,7 +329,7 @@ graphic 0xA1E0
 Cprop		canfix	i1
 int 85
 qtdtintas	4
-script usaquadro
+
 }
 Item 0x2413
 {
@@ -339,7 +339,7 @@ graphic 0x2413
 Cprop		canfix	i1
 int 85
 qtdtintas	4
-script usaquadro
+
 }
 Item 0xA1DE
 {
@@ -349,7 +349,7 @@ graphic 0xA1DE
 Cprop		canfix	i1
 int 85
 qtdtintas	4
-script usaquadro
+
 }
 Item 0xA1E2
 {
@@ -359,7 +359,7 @@ graphic 0xA1E2
 Cprop		canfix	i1
 int 85
 qtdtintas	4
-script usaquadro
+
 }
 //Quadro grande (90 int)
 Item 0x4C22
@@ -370,7 +370,7 @@ graphic 0x4C22
 Cprop		canfix	i1
 int 90
 qtdtintas	6
-script usaquadro
+
 }
 Item 0x234F
 {
@@ -380,7 +380,7 @@ graphic 0x234F
 Cprop		canfix	i1
 int 90
 qtdtintas	6
-script usaquadro
+
 }
 Item 0x0EA0
 {
@@ -390,7 +390,7 @@ graphic 0x0EA0
 Cprop		canfix	i1
 int 90
 qtdtintas	6
-script usaquadro
+
 }
 Item 0x2A5D
 {
@@ -400,7 +400,7 @@ graphic 0x2A5D
 Cprop		canfix	i1
 int 90
 qtdtintas	6
-script usaquadro
+
 }
 Item 0x2A65
 {
@@ -410,7 +410,7 @@ graphic 0x2A65
 Cprop		canfix	i1
 int 90
 qtdtintas	6
-script usaquadro
+
 }
 Item 0x2A66
 {
@@ -420,7 +420,7 @@ graphic 0x2A66
 Cprop		canfix	i1
 int 90
 qtdtintas	6
-script usaquadro
+
 }
 Item 0x2A69
 {
@@ -430,7 +430,7 @@ graphic 0x2A69
 Cprop		canfix	i1
 int 90
 qtdtintas	6
-script usaquadro
+
 }
 Item 0xA2C8
 {
@@ -440,7 +440,7 @@ graphic 0xA2C8
 Cprop		canfix	i1
 int 90
 qtdtintas	6
-script usaquadro
+
 }
 //Paisagem (100 int)
 Item 0x4C26
@@ -451,7 +451,7 @@ graphic 0x4C26
 Cprop		canfix	i1
 int 100
 qtdtintas	8
-script usaquadro
+
 }
 Item 0x4C28
 {
@@ -461,7 +461,7 @@ graphic 0x4C28
 Cprop		canfix	i1
 int 100
 qtdtintas	8
-script usaquadro
+
 }
 Item 0xA2DC
 {
@@ -471,7 +471,7 @@ graphic 0xA2DC
 Cprop		canfix	i1
 int 100
 qtdtintas	8
-script usaquadro
+
 }
 Item 0xA2DE
 {
@@ -481,7 +481,7 @@ graphic 0xA2DE
 Cprop		canfix	i1
 int 100
 qtdtintas	8
-script usaquadro
+
 }
 Item 0xA2E0
 {
@@ -491,7 +491,7 @@ graphic 0xA2E0
 Cprop		canfix	i1
 int 100
 qtdtintas	8
-script usaquadro
+
 }
 Item 0xA2E2
 {
@@ -501,7 +501,7 @@ graphic 0xA2E2
 Cprop		canfix	i1
 int 100
 qtdtintas	8
-script usaquadro
+
 }
 Item 0xA2E4
 {
@@ -511,7 +511,7 @@ graphic 0xA2E4
 Cprop		canfix	i1
 int 100
 qtdtintas	8
-script usaquadro
+
 }
 Item 0xA2E6
 {
@@ -521,7 +521,7 @@ graphic 0xA2E6
 Cprop		canfix	i1
 int 100
 qtdtintas	8
-script usaquadro
+
 }
 Item 0xA2F4
 {
@@ -531,7 +531,7 @@ graphic 0xA2F4
 Cprop		canfix	i1
 int 100
 qtdtintas	8
-script usaquadro
+
 }
 //Adornados
 Item 0x99A7
@@ -542,7 +542,7 @@ graphic 0x99A7
 Cprop		canfix	i1
 int 105
 qtdtintas	8
-script usaquadro
+
 }
 Item 0x99A9
 {
@@ -552,7 +552,7 @@ graphic 0x99A9
 Cprop		canfix	i1
 int 105
 qtdtintas	8
-script usaquadro
+
 }
 Item 0x99AB
 {
@@ -562,7 +562,7 @@ graphic 0x99AB
 Cprop		canfix	i1
 int 105
 qtdtintas	8
-script usaquadro
+
 }
 Item 0x99AD
 {
@@ -572,7 +572,7 @@ graphic 0x99AD
 Cprop		canfix	i1
 int 105
 qtdtintas	8
-script usaquadro
+
 }
 Item 0x99AF
 {
@@ -582,7 +582,7 @@ graphic 0x99AF
 Cprop		canfix	i1
 int 105
 qtdtintas	8
-script usaquadro
+
 }
 Item 0x99B1
 {
@@ -592,7 +592,7 @@ graphic 0x99B1
 Cprop		canfix	i1
 int 105
 qtdtintas	8
-script usaquadro
+
 }
 Item 0x99B3
 {
@@ -602,7 +602,7 @@ graphic 0x99B3
 Cprop		canfix	i1
 int 105
 qtdtintas	8
-script usaquadro
+
 }
 Item 0x99B5
 {
@@ -612,7 +612,7 @@ graphic 0x99B5
 Cprop		canfix	i1
 int 105
 qtdtintas	8
-script usaquadro
+
 }
 Item 0x99B7
 {
@@ -622,7 +622,7 @@ graphic 0x99B7
 Cprop		canfix	i1
 int 105
 qtdtintas	8
-script usaquadro
+
 }
 Item 0x99B9
 {
@@ -632,7 +632,7 @@ graphic 0x99B9
 Cprop		canfix	i1
 int 105
 qtdtintas	8
-script usaquadro
+
 }
 Item 0x99BB
 {
@@ -642,7 +642,7 @@ graphic 0x99BB
 Cprop		canfix	i1
 int 105
 qtdtintas	8
-script usaquadro
+
 }
 Item 0x99BD
 {
@@ -652,7 +652,7 @@ graphic 0x99BD
 Cprop		canfix	i1
 int 105
 qtdtintas	8
-script usaquadro
+
 }
 Item 0x99BF
 {
@@ -662,7 +662,7 @@ graphic 0x99BF
 Cprop		canfix	i1
 int 105
 qtdtintas	8
-script usaquadro
+
 }
 // Item 0x99C1
 // {
@@ -672,7 +672,7 @@ script usaquadro
 // 	Cprop		canfix	i1
 // 	int 105
 // 	qtdtintas	8
-// script usaquadro
+// 
 // }
 // Item 0x99C3
 // {
@@ -682,7 +682,7 @@ script usaquadro
 // 	Cprop		canfix	i1
 // 	int 105
 // 	qtdtintas	8
-// script usaquadro
+// 
 // }
 // Item 0x99C5
 // {
@@ -692,7 +692,7 @@ script usaquadro
 // 	Cprop		canfix	i1
 // 	int 105
 // 	qtdtintas	8
-// script usaquadro
+// 
 // }
 // //Obra Prima(110 int)
 // Item 0x4C34
@@ -703,7 +703,7 @@ script usaquadro
 // 	Cprop		canfix	i1
 // 	int 107
 // 	qtdtintas	8
-// script usaquadro
+// 
 // }
 // Item 0x4C33
 // {
@@ -713,7 +713,7 @@ script usaquadro
 // 	Cprop		canfix	i1
 // 	int 107
 // 	qtdtintas	8
-// script usaquadro
+// 
 // }
 // Item 0x4C32
 // {
@@ -723,5 +723,5 @@ script usaquadro
 // 	Cprop		canfix	i1
 // 	int 107
 // 	qtdtintas	8
-// script usaquadro
+// 
 // }


### PR DESCRIPTION
3 arquivos, sendo o criarquadrorp (comando), o useimage que controla a ação do player e retirado o script usaquadro do itemdesc de quadros.

o comando criaquadrorp checa se o player é gm, se é item, se não é container e se não tem scripts associados para evitar desativar algum script de duplo clique que ja existe, como na pedra de criacao