### PR TITLE
gump criacao, arrumando cores e manter estado do selecionado

### DIFF
--- a/pkg/items/hair/config/hairColors.cfg
+++ b/pkg/items/hair/config/hairColors.cfg
@@ -278,11 +278,11 @@ HairColor Cabelo Elfo
 	Color	1051
 // Numajenes
 	Color	1818
-	Color	1044
-	Color	1836
-	Color	1854
-	Color	1845
-	Color	1051
+	//Color	1044 repetida
+	//Color	1836 repetida
+	//Color	1854 repetida
+	//Color	1845 repetida
+	//Color	1051 repetida
 	Color	1907
 	Color	1899
 	Color	1109
@@ -432,7 +432,8 @@ HairColor Cabelo Drow
     Color   296
     Color   301
     Color   306
-    Color   500
+    //Color   500 // apesar da cor ser valida, em epicgumpcriacao.src > hairAndBeardColorSelection, o valor 500 interrompe o loop
+	//  isso provavelmente tem um uso que eu desconheço, portanto estou removendo a cor pra cabelo de drow
     Color   501
     Color   926
     Color   930

--- a/pkg/items/hair/config/hairColors.cfg
+++ b/pkg/items/hair/config/hairColors.cfg
@@ -432,8 +432,7 @@ HairColor Cabelo Drow
     Color   296
     Color   301
     Color   306
-    //Color   500 // apesar da cor ser valida, em epicgumpcriacao.src > hairAndBeardColorSelection, o valor 500 interrompe o loop
-	//  isso provavelmente tem um uso que eu desconheço, portanto estou removendo a cor pra cabelo de drow
+	Color   500
     Color   501
     Color   926
     Color   930

--- a/pkg/systems/charactercreation/epicgumpcriacao.src
+++ b/pkg/systems/charactercreation/epicgumpcriacao.src
@@ -559,6 +559,9 @@ function looksSelection(who)
     chardata.+hair_item := 0;
     var continue_loop := 1;
 
+    //reseta cabelo e barba antes de iniciar as opções
+    resetHairAndBeard(who, chardata);
+
     while (continue_loop)
         var input := hairSelectionGump(who, chardata, currentPage);
         btn_value := input[0];
@@ -596,6 +599,20 @@ function looksSelection(who)
     skinColorSelection(who, chardata);
 endfunction
 
+function resetHairAndBeard(who, byref chardata)
+    if (chardata)
+        chardata.beard := "";
+        chardata.beard_item := "";
+        chardata.beard_color := "";
+        DestroyItem(GetEquipmentByLayer(who, LAYER_BEARD));
+
+        chardata.hair := "";
+        chardata.hair_item := "";
+        chardata.hair_color := "";
+        DestroyItem(GetEquipmentByLayer(who, LAYER_HAIR));
+    endif
+endfunction
+
 function hairAndBeardColorSelection(who, byref chardata)
     var btn_value;
     var currentPage := 1;
@@ -607,7 +624,7 @@ function hairAndBeardColorSelection(who, byref chardata)
         case (btn_value)
             1001: currentPage += 1; // Next page
             1002: currentPage -= 1; // Previous page
-            500: 
+            1003: 
                 continue_loop := 0; // This will break the loop
             default: 
                 if (btn_value)

--- a/pkg/systems/charactercreation/epicgumpcriacao.src
+++ b/pkg/systems/charactercreation/epicgumpcriacao.src
@@ -588,15 +588,15 @@ function looksSelection(who)
         beardSelection(who, chardata);
     endif
     
-    //caso cabelo e barba não tenham sido selecionados, pular opcao de cor
-    if (chardata.hair != "" || chardata.beard != "") 
-        colorSelection(who, chardata);
+    //caso cabelo e barba não tenham sido selecionados, pular opcao de cor de cabelo e barba
+    if ((chardata.hair && chardata.hair != "") || (chardata.beard && chardata.beard != ""))
+        hairAndBeardColorSelection(who, chardata);
     endif
 
     skinColorSelection(who, chardata);
 endfunction
 
-function colorSelection(who, byref chardata)
+function hairAndBeardColorSelection(who, byref chardata)
     var btn_value;
     var currentPage := 1;
     var continue_loop := 1;
@@ -611,7 +611,9 @@ function colorSelection(who, byref chardata)
                 continue_loop := 0; // This will break the loop
             default: 
                 if (btn_value)
-                    chardata.hair_color := btn_value;
+                    if (chardata.hair_item)
+                        chardata.hair_color := btn_value;
+                    endif
                     if (chardata.beard_item)
                         chardata.beard_color := btn_value;
                     endif

--- a/scripts/include/creationUtils.inc
+++ b/scripts/include/creationUtils.inc
@@ -2163,15 +2163,22 @@ function hairAndBeardColorSelectionGump(who, byref chardata, currentPage := 1)
     var start := (currentPage - 1) * COLORS_PER_PAGE + 1;
     var end := Min(start + COLORS_PER_PAGE - 1, totalColors);
 
+    var selectedColor := (chardata.hair_item) ? chardata.hair_color : chardata.beard_color;
+
     var y_pos := 100;
     for i := start to end
         var colorData := allColors[i];
         var color := CInt(colorData.color);
         var category := colorData.category;
-
-        GFAddButton(gump, 257, y_pos, 0x9C4E, 0x9C4F, GF_CLOSE_BTN, color);
+        
+        //se houver uma cor selecionada, então dá check o botão correto na iteração
+        if (selectedColor == color)
+            GFAddButton(gump, 257, y_pos, 0x9C4F, 0x9C4E, GF_CLOSE_BTN, color);
+        else
+            GFAddButton(gump, 257, y_pos, 0x9C4E, 0x9C4F, GF_CLOSE_BTN, color);
+        endif
         GFHTMLArea(gump, 135, y_pos + 2, 122, 20, "", 1, 0);
-        GFTextLine(gump, 142, y_pos + 4, color, category);
+        GFTextLine(gump, 142, y_pos + 4, color-1, category); //hue de cor tem que ter -1
         y_pos += 20;
     endfor
 
@@ -2281,14 +2288,20 @@ function skinColorSelectionGump(who, byref chardata, currentPage := 1)
 
     var start := (currentPage - 1) * COLORS_PER_PAGE + 1;
     var end := Min(start + COLORS_PER_PAGE, totalColors);
-
+    var skinColor := chardata.skin_color;
+    
     var y_pos := 100;
     for i := start to end
         var color := CInt(allColors[i]);
 
-        GFAddButton(gump, 257, y_pos, 0x9C4E, 0x9C4F, GF_CLOSE_BTN, color);
+        //se houver uma cor selecionada, então dá check o botão correto na iteração
+        if (skinColor == color)
+            GFAddButton(gump, 257, y_pos, 0x9C4F, 0x9C4E, GF_CLOSE_BTN, color);
+        else
+            GFAddButton(gump, 257, y_pos, 0x9C4E, 0x9C4F, GF_CLOSE_BTN, color);
+        endif
         GFHTMLArea(gump, 135, y_pos + 2, 122, 20, "", 1, 0);
-        GFTextLine(gump, 142, y_pos + 4, color, "Cor " + (i - start + 1));
+        GFTextLine(gump, 142, y_pos + 4, color - 1, "Cor " + i); //hue de cor tem que ter -1
         y_pos += 20;
     endfor
 

--- a/scripts/include/creationUtils.inc
+++ b/scripts/include/creationUtils.inc
@@ -2194,7 +2194,7 @@ function hairAndBeardColorSelectionGump(who, byref chardata, currentPage := 1)
     endif
 
     // Adicionar botão de fechar
-    GFAddButton(gump, 653, 680, 4005, 4007, GF_CLOSE_BTN, 500);
+    GFAddButton(gump, 653, 680, 4005, 4007, GF_CLOSE_BTN, 1003);
 
     return GFSendGump(who, gump);
 endfunction


### PR DESCRIPTION
* Comentado cores de cabelo repetidas pra elfos
* Ao iniciar o processo de selecionar cabelo, o código limpa as escolhas anteriores para garantir que não haverá erros
* Cabelo já vem setado como careca no valor default quando o gump de seleção abre
* Barba já vem setado como sem barba no valor default quando o gump de seleção abre
* Valida a necessidade de ter ao menos cabelo ou barba pra ir pra seleção de cores pra esse
* Arrumado as opções de cores para cabelo e barba (a cor que aparecia pra seleção não batia com a cor que estava sendo aplicado)
* Arrumado as opções de cores para pele (a cor que aparecia pra seleção não batia com a cor que estava sendo aplicado)
* Para cores (cabelo/barba e pele), o checkbox fica selecionado quando escolhido