### PR TITLE
Ajuste na dificuldade de armas de fogo e munições

### DIFF
--- a/pkg/skills/metalworking/tinker.cfg
+++ b/pkg/skills/metalworking/tinker.cfg
@@ -1657,8 +1657,8 @@ tinkeritem 0xC5FD
 {
 	name            pistol1
 	desc            pistola canhota
-    skill    	    60
-	difficulty 	    60
+    skill    	    50
+	difficulty 	    50
 	points 		    20
 	exceptional	1
 	mark		1
@@ -1677,8 +1677,8 @@ tinkeritem 0xC5FE
 {
 	name            pistol2
 	desc            pistola destra
-    skill    	    60
-	difficulty 	    60
+    skill    	    50
+	difficulty 	    50
 	points 		    20
 	exceptional	1
 	mark		1
@@ -1697,8 +1697,8 @@ tinkeritem 0xC5FF
 {
 	name            handcannon
 	desc            Canhao de Mao
-    skill    	    70
-	difficulty 	    70
+    skill    	    65
+	difficulty 	    65
 	points 		    20
 	exceptional	1
 	mark		1
@@ -1716,8 +1716,8 @@ tinkeritem 0xC600
 {
 	name            carabine
 	desc            Carabina
-    skill    	    80
-	difficulty 	    80
+    skill    	    70
+	difficulty 	    70
 	points 		    20
 	exceptional	1
 	mark		1
@@ -1735,8 +1735,8 @@ tinkeritem 0x89A7
 {
 	name            musket
 	desc            Mosquete
-    skill    	    92
-	difficulty 	    92
+    skill    	    85
+	difficulty 	    85
 	points 		    20
 	exceptional	1
 	mark		1
@@ -1759,8 +1759,8 @@ tinkeritem 0x9090
 	mark		1
 	retain	1
 
-	skill 55
-	difficulty 65
+	skill 45
+	difficulty 45
     materials metal 5
     text Um projetil para ser usado em armas de fogo
     Delay 2
@@ -1770,8 +1770,8 @@ tinkeritem 0x4224
 {
     name cannonball
     desc bola de canhao
-    skill 55
-	difficulty 65
+    skill 45
+	difficulty 45
     materials metal 25
     text Um bola de canhao. Um engenheiro de artilharia sabera o que fazer com isso
     Delay 2


### PR DESCRIPTION
Todas desceram um pouco a dificuldade, para que o engenheiro de artilharia principalmente possa fazer suas armas mais cedo.

Foi dividido em 2 tiers

Curto Alcance:
Pistola - Tier 1
Canhão de Mão - Tier 2

Médio-Longo Alcance:
Carabina - Tier 1
Mosquete - Tier 2