### PR TITLE
Correção de exploits possiveis para ress de pet com fidelizar, adicio…

### DIFF
--- a/pkg/mobiles/death/npcdeath.src
+++ b/pkg/mobiles/death/npcdeath.src
@@ -100,10 +100,15 @@ program core_npcDeath(params)
 		elseif(!getobjproperty(corpse, "Necro"))
 			GetNumPets(master);
 			var teste := GetObjProperty(corpse, "LastDP");
-			if ( GetObjProperty(corpse, "NeverRelease") && (GetObjProperty(corpse, "LastDP") >= 20 ) )
-				sleep(180);
-				res_pet(corpse);
-				return;
+			if ( GetObjProperty(corpse, "NeverRelease")) //&& 
+				//if (GetObjProperty(corpse, "LastDP") >= 10 ) ) // PARA TESTAR VOLTAR DPS
+					SendSysMessageEx(master, "Seu pet fiel irá acordar em 3 minutos", SSM_INFO);
+					sleep(180);
+					RessuscitarPet(corpse, master);
+					return;
+				//else
+					//SendSysMessageEx(master, "Seu pet fiel precisa ser reanimado!", SSM_FAIL);
+				//endif
 			endif
 		else
 			var numbersummons := Cint(GetObjProperty(master, "NecroSummons"));
@@ -379,73 +384,6 @@ function NoCorpseCheck(corpse, npc_cfg)
 	DestroyItem(corpse);
 	
 	return 1;
-endfunction
-
-function res_pet(corpse)
-	var npc := CreateNpcFromTemplate( GetObjProperty(corpse, "npctemplate"), corpse.x, corpse.y, corpse.z, 0, corpse.realm);
-	CopyProps(corpse, npc);
-	var corpse_parsed := corpse.name[13, len(corpse.name)-12];
-	npc.script := ":ghaia:tamed";
-	RestartScript(npc);
-	Setname(npc, corpse_parsed);
-	recalcvitals(npc);
-	var ownerserial := GetObjProperty(corpse, "owner");
-	var owner := SystemFindObjectBySerial(ownerserial);
-		if (!owner)
-			destama(npc.serial);
-		else
-			if ( (GetNumPets(owner) + GetPetCost(npc)) > GetMaxPets(owner) )
-				SendSysMessageEx(owner, "Voce ja tem muitos animais.", SSM_FAIL);
-				destama(npc.serial);
-			else
-				AddPet(owner, npc.serial);
-			endif
-		endif
-
-	DestroyItem(corpse);
-	SetCooldown(npc, "resurrect", 180);
-	var skills := GetObjProperty(npc, "petskills");
-    foreach skill in (skills.keys())
-        AP_SetTrueSkill(npc, skill, skills[skill]);
-    endforeach
-
-//Desconta o DP dos fieis
-if ( (Getobjproperty(npc, "bond") == "fiel") )
-	var DP := AP_GetVital(npc, "DP");
-	AP_SetVital(npc, "DP", DP -10);
-    if (DP < 0)
-        AP_SetVital(npc, "DP", 0);
-    endif
-endif
-
-//Para repor as habs do despertar natureza do pet
-var instincts := GetObjProperty(npc,"instincts");
-var ferocidade := instincts["Ferocidade"].ins_name;
-var fortaleza := instincts["Fortaleza"].ins_name;
-var flexibilidade := instincts["Flexibilidade"].ins_name;
-if (!instincts)
-else
-	if (ferocidade == "Ferocidade")
-		AP_SetTrueStat(npc, STRENGTH, AP_GetStat(npc, STRENGTH) + 15);
-	endif
-	if (fortaleza == "Fortaleza")
-		var hits := CInt(AP_GetVitalMaximumValue(npc, "Hits"));
-		var variavel := Cint(hits / 3);
-		var variavel2 := Cint(variavel /2); //não sei pq ele duplica por isso a divisão pela metade
-		setObjProperty(npc, "hitsmod", variavel2);
-	endif
-	if (flexibilidade == "Flexibilidade")
-		AP_SetTrueStat(npc, DEXTERITY, AP_GetStat(npc, DEXTERITY) + 15);
-	endif
-	RecalcVitals(npc);
-endif
-endfunction
-
-function CopyProps(origin, destiny)
-	var propnames := GetObjPropertyNames(origin);
-	foreach prop in propnames
-		SetObjPRoperty(destiny, prop, GetObjProperty(origin, prop));
-	endforeach
 endfunction
 
 function PushBackEX(who, dist, delay, invert := 0)

--- a/pkg/mobiles/ghaia/tamed.src
+++ b/pkg/mobiles/ghaia/tamed.src
@@ -427,38 +427,44 @@ endif
 			PrintTextAbovePrivate(me,"O animal já está satisfeito", ev.source);
 			return;
 		endif
-		//checkbond para ver se já tem animal fidelizado
-		var check_bond := 0;
-		var pets := GetObjProperty(owner, "TamedPets");
-		var habs := TemHabilidade(owner, "Espreita Selvagem") || TemHabilidade(owner, "Rei do Gado");
-			foreach serial in pets
-				var pet := SystemFindObjectBySerial(serial);
-			if (GetObjProperty(pet, "bond") == "fiel")
-				if (!habs )
-					check_bond := 1;
-				else
-					check_bond := 2;
-				endif
-			endif
-			endforeach
-		if ((happy >= 20) && (ev.source == owner)) //checa a felicidade e se o dono que está dando comida
-			if (Cint(startbond)) //checa o bond para fidelizar
+//checkbond para ver se já tem animal fidelizado e quantos pode ter
+var pets := GetObjProperty(owner, "TamedPets");
+var habs := TemHabilidade(owner, "Espreita Selvagem") || TemHabilidade(owner, "Rei do Gado");
+var limite_animais := habs ? 2 : 1;
+var animais_fidelizados := 0;
 
-				if ( (adestramento >= 1) && (tempo_fiel <= timebond) ) // Pelo menos 1 de skill e o tempo que demoraria para fidelizar tem q ser menor que o tempo de agora
-					SetObjProperty(me, "bond", "fiel");
-					SetobjProperty(me, "NeverRelease", 1);
-					PrintTextAbovePrivate(me, "*O animal se esfrega em voce*", owner);
-					PlaySoundEffect(me, npccfg[me.npctemplate].idlesound);
-					SendSysMessage(owner, +me.name+ " criou um vinculo de fidelidade com voce!", 0, 61);
-					SetObjProperty(me, "dpmod", -20);
-					RecalcVitals(me);
-				endif
-			elseif ((startbond == "fiel") || (check_bond == 1) || (fidelizar == "nao") ) //se já é fiel/se já tem animal fidelizado/marcado como nao fidelizar só vai comer
-			else //para iniciar o bond
-				SetObjProperty(me, "bond", timebond);
-				SendSysMessageEX(owner, "Voce comeca a construir uma fidelidade com seu animal.", SSM_INFO);
-			endif
-		endif
+foreach serial in pets
+    var pet := SystemFindObjectBySerial(serial);
+    if (GetObjProperty(pet, "bond") == "fiel")
+        animais_fidelizados := animais_fidelizados + 1;
+        if (animais_fidelizados > 2)
+            break; // Não precisamos contar além de 2
+        endif
+    endif
+endforeach
+
+if ((happy >= 20) && (ev.source == owner)) //checa a felicidade e se o dono que está dando comida
+    if (Cint(startbond)) //checa o bond para fidelizar
+        if ((adestramento >= 1) && (tempo_fiel <= timebond)) // Pelo menos 1 de skill e o tempo que demoraria para fidelizar tem q ser menor que o tempo de agora
+            if (animais_fidelizados < limite_animais && animais_fidelizados < 2)
+                SetObjProperty(me, "bond", "fiel");
+                SetobjProperty(me, "NeverRelease", 1);
+                PrintTextAbovePrivate(me, "*O animal se esfrega em voce*", owner);
+                PlaySoundEffect(me, npccfg[me.npctemplate].idlesound);
+                SendSysMessage(owner, +me.name+ " criou um vinculo de fidelidade com voce!", 0, 61);
+                SetObjProperty(me, "dpmod", -20);
+                RecalcVitals(me);
+            else
+                SendSysMessageEX(owner, "Voce ja atingiu o limite de animais fidelizados.", SSM_INFO);
+            endif
+        endif
+    elseif ((startbond == "fiel") || (animais_fidelizados >= limite_animais) || (fidelizar == "nao")) //se já é fiel/se já atingiu o limite de animais fidelizados/marcado como nao fidelizar só vai comer
+        // Nada acontece, o animal só come
+    else //para iniciar o bond
+        SetObjProperty(me, "bond", timebond);
+        SendSysMessageEX(owner, "Voce comeca a construir uma fidelidade com seu animal.", SSM_INFO);
+    endif
+endif
 		PlaySoundEffect(me, CInt(0x3b)+ RandomInt(3));
 		if (ev.item.amount >1)
 			SubtractAmount(ev.item, 1);

--- a/pkg/skills/animalhandle/taming/include/taming.inc
+++ b/pkg/skills/animalhandle/taming/include/taming.inc
@@ -389,3 +389,103 @@ function ErasePetMods(pet)
 	endif
 
 endfunction
+
+function RessuscitarPet(corpse, owner, is_bandage := 0)
+    var npc := CreateNpcFromTemplate(GetObjProperty(corpse, "npctemplate"), corpse.x, corpse.y, corpse.z, 0, corpse.realm);
+    CopyProps(corpse, npc);
+    var corpse_parsed := corpse.name[13, len(corpse.name)-12];
+    npc.script := ":ghaia:tamed";
+    RestartScript(npc);
+    SetName(npc, corpse_parsed);
+    RecalcVitals(npc);
+
+    // Lógica de contagem de animais fidelizados
+    var pets := GetObjProperty(owner, "TamedPets");
+    var habs := TemHabilidade(owner, "Espreita Selvagem");
+    var limite_animais := habs ? 2 : 1;
+    var animais_fidelizados := 0;
+    foreach serial in pets
+        var pet := SystemFindObjectBySerial(serial);
+        if (GetObjProperty(pet, "bond") == "fiel")
+            animais_fidelizados := animais_fidelizados + 1;
+            if (animais_fidelizados > 2)
+                break;
+            endif
+        endif
+    endforeach
+
+	//Checagem de limite de slots de animais
+    if (!owner)
+        destama(npc.serial);
+    else
+        if ((GetNumPets(owner) + GetPetCost(npc)) > GetMaxPets(owner))
+            SendSysMessageEx(owner, "Voce ja tem muitos animais.", SSM_FAIL);
+            destama(npc.serial);
+        elseif ( GetObjProperty(npc, "bond") == "fiel" && animais_fidelizados >= limite_animais)
+            SendSysMessageEx(owner, "O animal sente-se traído por você ter atingido o limite de animais fieis.", SSM_FAIL);
+            destama(npc.serial);
+        else
+            AddPet(owner, npc.serial);
+        endif
+    endif
+
+    DestroyItem(corpse);
+    SetCooldown(npc, "resurrect", is_bandage ? 120 : 180);
+    var skills := GetObjProperty(npc, "petskills");
+    foreach skill in (skills.keys())
+        AP_SetTrueSkill(npc, skill, skills[skill]);
+    endforeach
+
+    // Desconta o DP dos fieis
+    if (GetObjProperty(npc, "bond") == "fiel")
+        var DP := AP_GetVital(npc, "DP");
+        AP_SetVital(npc, "DP", DP - 10);
+        if (DP < 0)
+            AP_SetVital(npc, "DP", 0);
+        endif
+    endif
+
+    // Repõe as habilidades do despertar natureza do pet
+    var instincts := GetObjProperty(npc, "instincts");
+    if (instincts)
+        if (instincts["Ferocidade"].ins_name == "Ferocidade")
+            AP_SetTrueStat(npc, STRENGTH, AP_GetStat(npc, STRENGTH) + 15);
+        endif
+        if (instincts["Fortaleza"].ins_name == "Fortaleza")
+            var hits := CInt(AP_GetVitalMaximumValue(npc, "Hits"));
+            var variavel := CInt(hits / 3);
+            var variavel2 := CInt(variavel / 2);
+            SetObjProperty(npc, "hitsmod", variavel2);
+        endif
+        if (instincts["Flexibilidade"].ins_name == "Flexibilidade")
+            AP_SetTrueStat(npc, DEXTERITY, AP_GetStat(npc, DEXTERITY) + 15);
+        endif
+        RecalcVitals(npc);
+    endif
+	
+	//Checar a felicidade do animal quando ressuscita
+			var happy := GetObjProperty(npc,"happiness"); //happiness do pet
+			var fiel := GetObjProperty(npc, "NeverRelease"); // se é animal fiel
+			if (happy)
+				SetObjProperty(npc,"happiness", happy -20);
+				if(happy < 10 )
+					if (!fiel) //destama se happiness menor que 10
+						SendSysMessage(owner, "*Seu pet "+npc.name+" decidiu que eh melhor ficar sozinho*");
+						destama(npc.serial);
+//					else // se é fiel só perde fidelidade
+//						SendSysMessage(owner, "*Seu pet "+npc.name+" nao sente mais tanta confiança em você**");
+//						EraseObjProperty(npc, "NeverRelease");
+//						EraseObjProperty(npc, "bond");
+					endif
+				endif
+			endif
+
+    return npc;
+endfunction
+
+function CopyProps(origin, destiny)
+    var propnames := GetObjPropertyNames(origin);
+    foreach prop in propnames
+        SetObjProperty(destiny, prop, GetObjProperty(origin, prop));
+    endforeach
+endfunction

--- a/pkg/skills/animalhandle/taming/include/taming.inc
+++ b/pkg/skills/animalhandle/taming/include/taming.inc
@@ -392,7 +392,7 @@ endfunction
 
 function RessuscitarPet(corpse, owner, is_bandage := 0)
     var npc := CreateNpcFromTemplate(GetObjProperty(corpse, "npctemplate"), corpse.x, corpse.y, corpse.z, 0, corpse.realm);
-    CopyProps(corpse, npc);
+    CopyPropsPet(corpse, npc);
     var corpse_parsed := corpse.name[13, len(corpse.name)-12];
     npc.script := ":ghaia:tamed";
     RestartScript(npc);
@@ -483,7 +483,7 @@ function RessuscitarPet(corpse, owner, is_bandage := 0)
     return npc;
 endfunction
 
-function CopyProps(origin, destiny)
+function CopyPropsPet(origin, destiny)
     var propnames := GetObjPropertyNames(origin);
     foreach prop in propnames
         SetObjProperty(destiny, prop, GetObjProperty(origin, prop));

--- a/pkg/skills/animalhandle/taming/taming.src
+++ b/pkg/skills/animalhandle/taming/taming.src
@@ -6,8 +6,7 @@ use util;
 include ":attributes:attributes";
 include ":attributes:stats";
 include ":brainAI:include/npcCommands";
-include ":gumps:gumps_ex";
-include ":gumps:gumps"; //add
+include ":gumps:epicGumps";
 include "include/say";
 include ":taming:taming";
 include ":mounts:mounts";
@@ -34,17 +33,17 @@ set_script_option(SCRIPTOPT_CAN_ACCESS_OFFLINE_MOBILES, 1);
 
 program TamingSkill(who)
 	if ( GetObjProperty(who, "#medding") )
-		SendSysMessageEx(who, "Voce nao pode adestrar nada agora.", SSM_FAIL);
+		SendSysMessageEx(who, "Você não pode adestrar nada agora.", SSM_FAIL);
 		return;
 	elseif (GetObjProperty(who, "#tamewait") > ReadGameClock() )
-		SendSysMessage(who, "Voce precisa esperar para usar esta skill denovo.", SSM_FAIL);
+		SendSysMessage(who, "Você precisa esperar para usar esta skill de novo.", SSM_FAIL);
 		return;
 	endif
 
 //checar se já tem animal fidelizado
 	var check_bond := 0;
 	var petsi := GetObjProperty(who, "TamedPets");
-	var habs := TemHabilidade(who, "Espreita Selvagem") || TemHabilidade(who, "Rei do Gado");
+	var habs := TemHabilidade(who, "Espreita Selvagem");
 		foreach serial in petsi
 			var pety := SystemFindObjectBySerial(serial);
 			if (GetObjProperty(pety, "bond") == "fiel")
@@ -56,32 +55,24 @@ program TamingSkill(who)
 			endif
 		endforeach
 
-	var yn_gump := GFCreateGump(140, 120);
+	var yn_gump := GFECreateGump("Menu de Trato de Animais", 275, 290);
 
-	GFClosable(yn_gump, 1);
-	GFResizePic(yn_gump, 0, 0, GFCfgConst("Defaults", "BackGround"), 300, 280); //205);
-	GFResizePic(yn_gump, 15, 15, GFCfgConst("Defaults", "ForeGround"), 270, 250); //175);
+	GFAddButton(yn_gump, 20, (73), 2117, 2118, GF_CLOSE_BTN, 1);
+	GFTextLine(yn_gump, 40, 70, 1153, "Adestrar Animal.");
 
-	var y_pos := 20;
+	GFAddButton(yn_gump, 20, (93), 2117, 2118, GF_CLOSE_BTN, 2);
+	GFTextLine(yn_gump, 40, 90, 1153, "Informações sobre o animal.");
 
-	GFTextMid(yn_gump, 20, 25, 300, 55, "Menu de Trato de Animais");
-
-	GFAddButton(yn_gump, 20, (63), 2117, 2118, GF_CLOSE_BTN, 1);
-	GFTextLine(yn_gump, 40, 60, 1153, "Adestrar Animal.");
-
-	GFAddButton(yn_gump, 20, (83), 2117, 2118, GF_CLOSE_BTN, 2);
-	GFTextLine(yn_gump, 40, 80, 1153, "Informações sobre o animal.");
-
-	if (TemHabilidade(who, "Mestre de Feras") /* || TemHabilidade(who, "Despertar Natureza") */ ) // juntei tudo Igor
-		GFAddButton(yn_gump, 20, (103), 2117, 2118, GF_CLOSE_BTN, 3);
-		GFTextLine(yn_gump, 40, 100, 1153, "Despertar");
+	if (TemHabilidade(who, "Mestre de Feras"))
+		GFAddButton(yn_gump, 20, (113), 2117, 2118, GF_CLOSE_BTN, 3);
+		GFTextLine(yn_gump, 40, 110, 1153, "Despertar");
 	endif
 
-	GFTextLine(yn_gump, 20, 130, 1153, "Libertar Animal:");
+	GFTextLine(yn_gump, 25, 133, 1153, "Libertar Animal:");
 
 	if ( (check_bond == 0 || check_bond == 2) && (AP_GetSkill(who, HANDLEANIMAL) >= 1) )
-		GFAddButton(yn_gump, 190, (243), 2117, 2118, GF_CLOSE_BTN, 4);
-		GFTextLine(yn_gump, 210, 240, 1153, "Fidelizar?");
+		GFAddButton(yn_gump, 190, (253), 2117, 2118, GF_CLOSE_BTN, 4);
+		GFTextLine(yn_gump, 210, 250, 1153, "Fidelizar?");
 	endif
 
 	var y := 150;
@@ -91,7 +82,7 @@ program TamingSkill(who)
 		var pet := SystemFindObjectBySerial(serial);
 		var text_fiel := "";
 		if (GetObjProperty(pet, "bond") == "fiel")
-			text_fiel := " *fiel*";//<basefont color=#34eb7a>
+			text_fiel := " *fiel*";
 			GFTextLine(yn_gump, 40, y, 0xf7, "" + pet.name + text_fiel);
 		else
 			GFTextLine(yn_gump, 40, y, 1153, "" + pet.name);
@@ -108,17 +99,6 @@ program TamingSkill(who)
 		y := y + 20;
 	endforeach
 
-/*	 pets := GetObjProperty(who, "SummonedPets");
-	foreach serial in pets
-		var pet := SystemFindObjectBySerial(serial);
-		GFTextLine(yn_gump, 40, y, 1153, "" + pet.name + "(invocado)");
-		if (GetObjProperty(pet, "summoned"))
-			GFAddButton(yn_gump, 20, y+4, 2103, 2104, GF_CLOSE_BTN, (100+i));
-		endif
-		i := i + 1;
-		y := y + 20;
-	endforeach*/
-
 	var input := GFSendGump(who, yn_gump);
 	input := input[0];
 
@@ -129,19 +109,19 @@ program TamingSkill(who)
 	elseif (input == 3)
 		Teach(who);
 	elseif (input > 100)
-		SendSysMessageEx(who, "Voce libertou seu animal.", SSM_INFO);
+		SendSysMessageEx(who, "Você libertou seu animal.", SSM_INFO);
 		ErasePet(who, pets[input-100]);
 		destama(pets[input-100]);
 	elseif (input == 4) // botão para poder fidelizar
-		SendSysMessageEx(who, "Qual pet voce quer poder fidelizar? OBS: O processo sera resetado para qualquer outro pet com fidelizacao iniciada!", SSM_INFO);
+		SendSysMessageEx(who, "Qual pet você quer poder fidelizar? OBS: O processo será resetado para qualquer outro pet com fidelização iniciada!", SSM_INFO);
 		var targx := target(who);
 		if (GetObjProperty(targx,"owner") != who.serial)
-			SendSysMessageEx(who, "Esse animal nao lhe pertence!", SSM_FAIL);
+			SendSysMessageEx(who, "Esse animal não lhe pertence!", SSM_FAIL);
 			return;
 		endif
 		//resetar os demais para "nao" e deixa só o selecionado como "sim"
 		var pets_all := GetObjProperty(who, "TamedPets");
-		var habs := TemHabilidade(who, "Espreita Selvagem") || TemHabilidade(who, "Rei do Gado");
+		var habs := TemHabilidade(who, "Espreita Selvagem");
 		foreach serial in pets_all
 			var pet_each := SystemFindObjectBySerial(serial);
 			if ( habs && GetObjProperty(pet_each, "bond") == "fiel")
@@ -151,7 +131,7 @@ program TamingSkill(who)
 			endif
 		endforeach
 		SetObjProperty(targx, "Fidelizar?", "sim");
-		SendSysmessage(who, ""+targx.name+" pode ser fidelizado, todos os demais agora nao");
+		SendSysmessage(who, ""+targx.name+" pode ser fidelizado, todos os demais agora não");
 
 	endif
 
@@ -164,7 +144,7 @@ function taming(who)
 		who.hidden := 0;
 	endif
 
-	SendSysMessageEx(who, "Que animal voce deseja adestrar?", SSM_REQUEST);
+	SendSysMessageEx(who, "Que animal você deseja adestrar?", SSM_REQUEST);
 	if( who.hidden )
 		who.hidden := 0;
 	endif
@@ -173,43 +153,24 @@ function taming(who)
 	var skill := AP_GetSkill(who, HANDLEANIMAL);
 
 	var bonus := 0;
-//	SendSysMEssage(who, " " + GetNumPets(who) + " " + GetPetCost(targ) + " " + GetMaxPets(who) );
 	if ( !targ.IsA(POLCLASS_NPC) )
 		SendSysMessageEx(who, "Cancelado", SSM_FAIL);
 		return;
-//	elseif (Distance(who,targ) > 4)
-//		SendSysMessage(who, "Alvo esta muito distante.");
-//		return;
 	elseif ( targ.script[":ghaia:tamed"] )
-		//if( targ.master.serial == who.serial )
-		//	TeachGump(who, targ);
-		//else
-		SendSysMessageEx(who, targ.name+" nao pode ser adestrado.", SSM_FAIL);
-		//endif
+		SendSysMessageEx(who, targ.name+" não pode ser adestrado.", SSM_FAIL);
 		return 0;
 	elseif ( (GetNumPets(who) + GetPetCost(targ)) > GetMaxPets(who) )
 		SendSysMessageEx(who, "Este animal excede a sua capacidade atual de animais domesticados.", SSM_FAIL);
 		return 0;
-	else
-		if(TemHabilidade(who, "Rei do Gado") && (GetPetCost(targ) > 1))
-			SendSysMessageEx(who, "Rei do gado nao doma animais de mais de 1 slot.", SSM_FAIL);
-			return 0;
-		elseif(TemHabilidade(who, "Boiadeiro") && (GetPetCost(targ) > 2))
-			SendSysMessageEx(who, "Boiadeiro nao doma animais de mais de 2 slots.", SSM_FAIL);
-			return 0;
-		endif
-	/*elseif (who.serial IN GetObjProperty(targ, "#critical"))
-		SendSysMessage(who, targ.name+" nao aceita mais ser domado por voce.");
-		return 0;*/
 	endif
 
 	if(!CheckLineOfSight(who, targ))
-		SendSysMessage(who, "Voce nao pode ver isso!");
+		SendSysMessage(who, "Você não pode ver isso!");
 		return;
 	endif
 
 	if (isBoss(targ))
-		SendSysMessageEx(who, "Essa criatura nao aceita ser domesticada.", SSM_FAIL);
+		SendSysMessageEx(who, "Essa criatura não aceita ser domesticada.", SSM_FAIL);
 		return 0;
 	endif
 
@@ -217,9 +178,8 @@ function taming(who)
 	var npctemplate := targ.npctemplate;
 	npctemplate := npctemplate[10, len(npctemplate)-9];
 	cfg := cfg[npctemplate];
-//	Sendsysmessage(who, " " + cfg.TameDifficulty  + " " + skill);
 	if ( !cfg.TameDifficulty )
-		SendSysMessageEx(who, "Voce nao pode adestrar "+targ.name+".", SSM_FAIL);
+		SendSysMessageEx(who, "Voce não pode adestrar "+targ.name+".", SSM_FAIL);
 		return;
 	endif
 
@@ -229,11 +189,8 @@ function taming(who)
 	info.+facing := who.facing;
 	info.+difficulty := cfg.TameDifficulty;
 	if (info.difficulty > (skill + 15))
-		SendSysMessageEx(who, "Voce nao pode tentar adestrar "+targ.name+" ainda.");
+		SendSysMessageEx(who, "Você não pode tentar adestrar "+targ.name+" ainda.");
 		return 0;
-	//elseif (GetSkill(who, HANDLEANIMAL) < CInt(info.difficulty))
-	//	SendSysMessageEx(who, "Voce nao pode tentar adestrar "+targ.name+" ainda.");
-	//	return 0;
 	endif
 
 	cfg := 0;
@@ -246,7 +203,7 @@ function taming(who)
 
 			sleep(3);
 			if ( SkillCheck(who, HANDLEANIMAL, CInt(info.difficulty)) > 0 )
-				SendSysMessageEx(who, "Voce ganhou a confianca de "+targ.name+".", SSM_INFO);
+				SendSysMessageEx(who, "Você ganhou a confiança de "+targ.name+".", SSM_INFO);
 				targ.SetMaster(who);
 				var erase_selvagem := GetObjProperty(targ, "Selvagem");
 				SetObjProperty(targ, "owner", who.serial);
@@ -291,19 +248,19 @@ function TameLoop(who, targ, byref info)
 	var targ_hostiles := ListHostiles(targ, 15);
 
 	if ( targ.master )
-		SendSysMessage(who, targ.name+" nao pode ser adestrado.", SSM_FAIL);
+		SendSysMessage(who, targ.name+" não pode ser adestrado.", SSM_FAIL);
 		return 0;
 	elseif ( targ_hostiles.size() > 0 )
-		SendSysMessageEx(who, "alguem esta atacando "+targ.name+" .", SSM_FAIL);
+		SendSysMessageEx(who, "alguém está atacando "+targ.name+" .", SSM_FAIL);
 		return 0;
 	elseif ( my_hostiles.size() > 0 )
-		SendSysMessageEx(who, "Voce nao pode adestrar "+targ.name+" enquanto esta sendo atacado", SSM_FAIL);
+		SendSysMessageEx(who, "Você não pode adestrar "+targ.name+" enquanto está sendo atacado", SSM_FAIL);
 		return 0;
 	elseif ( (who.x != info.x) || (who.y != info.y) || (who.facing != info.facing) )
-		SendSysMessageEx(who, "Voce desviou sua atencao.", SSM_FAIL);
+		SendSysMessageEx(who, "Você desviou sua atenção.", SSM_FAIL);
 		return 0;
 	elseif ( Distance(who, targ) > 2 )
-		SendSysMessageEx(who, "Voce esta muito longe.", SSM_FAIL);
+		SendSysMessageEx(who, "Voêe está muito longe.", SSM_FAIL);
 		return 0;
 	endif
 
@@ -325,70 +282,36 @@ if(!ownerarray)
 		AI_Move(targ, who, NEMOVE_AWAY, NEMOVE_RUN, NOWAKE, 100);
 		sleepms(160);
 		if ( dist == Distance(who, targ) )
-			SendSysMessageEx(who, targ.name+" nao aceitou voce como dono.", SSM_FAIL);
+			SendSysMessageEx(who, targ.name+" não aceitou você como dono.", SSM_FAIL);
 		else
-			SendSysMessageEx(who, "Voce assustou "+targ.name+" .", SSM_FAIL);
+			SendSysMessageEx(who, "Você assustou "+targ.name+" .", SSM_FAIL);
 		endif
 		return 0;
 	else
-		SendSysMessageEx(who, "Voce falhou ao domar esse animal!", SSM_FAIL);
+		SendSysMessageEx(who, "Você falhou ao domar esse animal!", SSM_FAIL);
 		return 0;
-		//var dist := Distance(who, targ);
-		//SetObjProperty(targ, "#ForceFlee", 10);
-		//AI_Move(targ, who, NEMOVE_AWAY, NEMOVE_RUN, NOWAKE, 100);
-		//sleepms(160);
-		/*var critical := GetObjProperty(targ, "#critical");
-		if (!critical)
-			critical := array;
-			critical[1] := who.serial;
-		else
-			critical.append(who.serial);
-		endif
-		SetObjProperty(targ, "#critical", critical);
-		return 0;*/
 	endif
 endfunction
 
 function Teach(who)
-	if (/* !TemHabilidade(who, "Despertar Natureza") && */ !TemHabilidade(who, "Mestre de Feras") )
-		SendSysMessageEx(who, "Voce nao tem a habilidade para treinar animais domesticados.", SSM_FAIL);
+	if (!TemHabilidade(who, "Mestre de Feras") )
+		SendSysMessageEx(who, "Você não tem a habilidade para treinar animais domesticados.", SSM_FAIL);
 		return;
 	endif
 
-	SendSysMessage(who, "Selecione a criatura que voce deseja treinar.");
+	SendSysMessage(who, "Selecione a criatura que você deseja treinar.");
 	var creature := Target(who, TGTOPT_CHECK_LOS);
 	var instincts := GetObjProperty(creature, "instincts");
 	var bond := (Getobjproperty(creature, "bond") == "fiel") ;
 	if (!bond)
-		SendSysMessage(who, "Esse animal nao eh fiel a voce, conquiste a confianca dele primeiro!", 0, 32);
+		SendSysMessage(who, "Esse animal não é fiel a você, conquiste a confiança dele primeiro!", 0, 32);
 		return;
 	endif
-	var delay := GetObjProperty(who, "delayskill");
-	SetObjProperty(who, "delayskill", ReadGameClock() + 5);
-	if(delay)
-		if(delay > ReadGameClock())
-			SendSysMessage(who, "Voce ainda esta fazendo outra coisa.");
-			return;
-		endif
-	endif
+
 	if( GetObjProperty(creature, "Blocked") || creature.frozen )
-		SendSysMessage(who, "O raciocinio por tras da sua analise esta incorreto.");
+		SendSysMessage(who, "O raciocínio por trás da sua análise está incorreto.");
 		return 0;
 	endif
-
-	if( creature.serial == who.serial )
-		SendSysMessage(who, "Esse nao pode ser um alvo valido.");
-		return 0;
-	endif
-
-
-	if( (creature.graphic == 0x190) || (creature.graphic == 0x191) || (creature.graphic == 309) || (creature.graphic == 307) || (creature.graphic == 14) )
-		SendSysMessage(who, "Esse nao pode ser um alvo valido.");
-		return 0;
-	endif
-
-	//var category := lower(getnpccategory( ParseTemplateName(creature.npctemplate).template )); // Se necessário categorias
-
 
 	var advance_flags;
 	if(creature.script == ":ghaia:tamed")
@@ -396,7 +319,6 @@ function Teach(who)
 	else
 		return 0;
 	endif
-
 
 endfunction
 
@@ -436,13 +358,10 @@ function ProcessInput(who, creature, input)
 endfunction
 
 function GumpTemplate()
-	var gump := GFCreateGump(50,50);
+	var gump := GFECreateGump("MENU DESPERTAR", 350, 500);
 	GFPage(gump, 0);
-	GFResizePic(gump, 0, 0, BACKGROUND, 322, 485);
-	GFResizePic(gump, 2, 7, FOREGROUND, 313, 470);
-	GFTextLine(gump, 90, 20, 40, "NATUREZA E INSTINTOS");
-	GFGumpPic(gump, 150, 290, 1629); // jacaré primeiro lateral, segundo altura
-	GFGumpPic(gump, 10, 105, 1631); //boi
+	GFGumpPic(gump, 180, 290, 1629); // jacaré primeiro lateral, segundo altura
+	GFGumpPic(gump, 25, 105, 1631); //boi
 	GFPage(gump, 1);
 
 	return gump;
@@ -452,13 +371,10 @@ function BuildGump(who, creature)
 	var gump := template;
 	var y_pos := START_Y;
 
-
 	foreach index in index_list
 		var ins_elem := info_cfg[index];
-		//if( AP_GetSkill(who, ADESTRAMENTO) >= ins_elem.Skill )// retirado Sem necessidade
 			BuildInstincts(who, creature, gump, ins_elem, y_pos);
 			new_list.append(index);
-		//endif
 		SleepMS(2);
 	endforeach
 
@@ -482,13 +398,12 @@ function BuildInstincts(who, creature, byref gump, ins_elem, byref y_pos)
 	endif
 
 	if( y_pos == START_Y )//texto inicial e títulos
-		GFTextLine(gump, 178, 87, 10, "Mestre de Feras");
-		GFTextLine(gump, 12, 37, 0, "Você pode despertar a natureza (stats) ou ");
-		GFTextLine(gump, 12, 50, 0, "instinto selvagem (crítico-dano) do seu fiel animal.");
-		GFTextLine(gump, 12, 62, 0,	"Clique no botão para mais info sobre o instinto.");
-		GFTextLine(gump, 10, 437, 30,	" OBS: o animal só pode ter um despertar ou");
-		GFTextLine(gump, 10, 450, 30,	"   instinto (caso você saiba as duas habilidades)");
-		GFTextLine(gump, 30, 275, 90, "Mestre de Feras");
+		GFTextLine(gump, 200, 100, 10, "Despertar Natureza");
+		GFTextLine(gump, 45, 67, 0, "Você pode despertar a natureza (stats) ou o");
+		GFTextLine(gump, 45, 80, 0, "instinto (crítico-dano) do seu fiel animal.");
+		GFTextLine(gump, 45, 450, 30,	" 	OBS: o animal só pode ter uma natureza e");
+		GFTextLine(gump, 125, 463, 30,	"  			um instinto!");
+		GFTextLine(gump, 55, 290, 90, "Despertar Instintos");
 	endif
 
 	if(gump.cur_page > 1) //botão de número da página
@@ -498,7 +413,6 @@ function BuildInstincts(who, creature, byref gump, ins_elem, byref y_pos)
 var mount_packs := (creature.npctemplate == ":brainai:horse" || creature.npctemplate == ":brainai:horse2" || creature.npctemplate == ":brainai:horse3"|| creature.npctemplate == ":brainai:horse4" || creature.npctemplate == ":brainai:horse5" || creature.npctemplate == ":brainai:llama");// quem pode treinar animal de carga
 var sense_ones := (creature.npctemplate == ":brainai:dog" || creature.npctemplate == ":brainai:eagle"); // quem pode treinar sentido aguçado
 var npccfgfile := ReadConfigFile(":brainai:npcdesc");
-//var creature_who := creature.npctemplate;
 var creature_who := NPC_ParseTemplateName(creature.npctemplate).template;
 var creature_taxonomy := GetConfigString(npccfgfile[creature_who], "Taxonomy"); // identifca a taxonomy do npcdesc
 var pet_instinct := GetConfigStringArray(ins_elem, "Taxonomy"); // LISTA TODOS do cfg
@@ -506,36 +420,31 @@ var equal_taxonomy := (creature_taxonomy in pet_instinct); //identifica a taxono
 //print("A criatura eh "+creature_who+" Os taxonomys sao "+creature_taxonomy+" e os iguais sao "+equal_taxonomy); DEBUG
 	if( (ins_elem.Type == 0) && TemHabilidade(who, "Mestre de Feras") ) //listagem dos instintos naturais
 
-		GFTextLine(gump, 170, y_pos+20, 1890, ins_elem.Nome); // tive que listar individualmente pra não dar bode, a lista do cfg de acordo com o CONST inicial começa no 10
+		GFTextLine(gump, 190, y_pos+30, 1890, ins_elem.Nome); // tive que listar individualmente pra não dar bode, a lista do cfg de acordo com o CONST inicial começa no 10
 		if(ins_elem.Nome == "Ferocidade")
-		GFAddButton(gump, 290, y_pos+23, 1209, 1210, GF_PAGE_BTN, 10);
+		GFAddButton(gump, 310, y_pos+33, 1209, 1210, GF_PAGE_BTN, 10);
 
 		y_pos := y_pos+20;
 		elseif(ins_elem.Nome == "Flexibilidade")
-		GFAddButton(gump, 290, y_pos+23, 1209, 1210, GF_PAGE_BTN, 11);
+		GFAddButton(gump, 310, y_pos+33, 1209, 1210, GF_PAGE_BTN, 11);
 
 		y_pos := y_pos+20;
 		elseif(ins_elem.Nome == "Fortaleza")
-		GFAddButton(gump, 290, y_pos+23, 1209, 1210, GF_PAGE_BTN, 12);
+		GFAddButton(gump, 310, y_pos+33, 1209, 1210, GF_PAGE_BTN, 12);
 
 		y_pos := y_pos+20;
 		endif
-	//elseif (ins_elem.Type == 3 && mount_packs) //Aqui inseri o Animal de Carga, tem type diferente no cfg (3), RETIRADO!
-		//GFTextLine(gump, 170, y_pos+20, 1890, ins_elem.Nome);
-		//GFAddButton(gump, 290, y_pos+23, 1209, 1210, GF_PAGE_BTN, 14);
 
-		//y_pos := y_pos+20;
 	elseif ( (ins_elem.Type == 2 && sense_ones) && TemHabilidade(who, "Mestre de Feras") ) // Aqui inseri o senso aguçado, type 2 no cfg
 		GFTextLine(gump, 170, y_pos+20, 1890, ins_elem.Nome);
 		GFAddButton(gump, 290, y_pos+23, 1209, 1210, GF_PAGE_BTN, 13);
 
 		y_pos := y_pos+20;
 	elseif((ins_elem.Type == 1) && (equal_taxonomy) && TemHabilidade(who, "Mestre de Feras")) //instintos selvagens listados de acordo com o alvo e cfg
-	GFTextLine(gump, 27, y_pos+148, 1890, ins_elem.Nome);
+	GFTextLine(gump, 47, y_pos+160, 1890, ins_elem.Nome);
 	var det_pagex := ins_elem.Number; //inseri um valor number no cfg pra ficar mais facil para listar, lá começa no 15
-	GFAddButton(gump, 10, y_pos+151, 1209, 1210, GF_PAGE_BTN, det_pagex);
+	GFAddButton(gump, 27, y_pos+163, 1209, 1210, GF_PAGE_BTN, det_pagex);
 
-	//det_page := det_page + 5;
 	y_pos := y_pos+20;
 	else
 	if ( !TemHabilidade(who, "Mestre de Feras") )
@@ -545,7 +454,6 @@ var equal_taxonomy := (creature_taxonomy in pet_instinct); //identifica a taxono
 	elseif ( !TemHabilidade(who, "Mestre de Feras") )
 		GFTextLine(gump, 27, 334, 1890, "Você não tem a ");
 		GFTextLine(gump, 27, 346, 1890, "habilidade necessária.");
-		//y_pos := y_pos+10;
 	endif
 	endif
 
@@ -598,7 +506,7 @@ endfunction
 
 function TeachNow(who, tamed, ins)
 	if( Distance(who, tamed) > 1 )
-		SendSysMessage(who, "Voce nao vai conseguir ensinar nada de tao longe!");
+		SendSysMessage(who, "Você não vai conseguir ensinar nada de tão longe!");
 		return;
 	endif
 
@@ -608,10 +516,10 @@ function TeachNow(who, tamed, ins)
 	var ins_savage := GetObjProperty(tamed, "Group_savage");
 	var ins_2 := info_cfg[ins].Group;
 	if ((ins_2 == 1) && (ins_natural == 1)) //check para quem já tem 1 instinto natural e não pode mais pegar do mesmo tipo
-		SendSysMessage(who, "Voce ja despertou a natureza nesse animal!");
+		SendSysMessage(who, "Você já despertou a natureza nesse animal!");
 		return;
 	elseif ((ins_2 == 2) && (ins_savage == 1))// check para instinto selvagem e não poder pegar mais um
-		SendSysMessage(who, "Voce ja despertou o instinto selvagem nesse animal!");
+		SendSysMessage(who, "Você já despertou o instinto selvagem nesse animal!");
 		return;
 	else
 	endif
@@ -621,7 +529,7 @@ function TeachNow(who, tamed, ins)
 	endif
 
 	if(instincts[ins]) //não repetir hab no pet
-		SendSysMessage(who, "Este animal ja despertou esse instinto.");
+		SendSysMessage(who, "Este animal já despertou esse instinto.");
 		return;
 	endif
 
@@ -670,9 +578,11 @@ function TeachNow(who, tamed, ins)
 				//return;
 			//endif
 		endif
+		SendSysMessageEX(who, "Você despertou a natureza com sucesso.", SSM_INFO);
 	else
 		SetObjProperty(tamed, "Critic", critic); // Aqui define os criticos do instinto selvagem, TO DO -> script de criticos para definir essas habs
+		SendSysMessageEX(who, "Você despertou o instinto com sucesso.", SSM_INFO);
 	endif
 
-	SendSysMessageEX(who, "Voce despertou o instinto com sucesso.", SSM_INFO);
+	
 endfunction

--- a/pkg/skills/medicine/healing.src
+++ b/pkg/skills/medicine/healing.src
@@ -426,73 +426,10 @@ function HealNpcCorpse(mobile, targ, aux_skill)
 
 	if (  !GetObjProperty(targ,"morto") )
 		if ( SkillCheck(mobile, MEDICINE, diff) > 0 )
-			SendSysMessage(mobile, "Voce estabilizou o paciente.");
-			var npc := CreateNpcFromTemplate( GetObjProperty(targ, "npctemplate"), targ.x, targ.y, targ.z, 0, targ.realm);
-			CopyProps(targ, npc);
-			var targ_parsed := targ.name[10, len(targ.name)-9];
-			npc.script := ":ghaia:tamed";
-			RestartScript(npc);
-			npc.name := GetObjProperty(npc, "name");
-			Setname(npc, targ_parsed);
-			recalcvitals(npc);
 			var ownerserial := GetObjProperty(targ, "owner");
-			var owner := SystemFindObjectBySerial(ownerserial);
-			if (!owner)
-				destama(npc.serial);
-			else
-				if ( (GetNumPets(owner) + GetPetCost(npc)) > GetMaxPets(owner) )
-					SendSysMessageEx(owner, "Voce ja tem muitos animais.", SSM_FAIL);
-					destama(npc.serial);
-				else
-					AddPet(owner, npc.serial);
-				endif
-			endif
-			DestroyItem(targ);
-			SetCooldown(npc, "resurrect", 120);
-			var skills := GetObjProperty(npc, "petskills");
-			foreach skill in (skills.keys())
-				AP_SetTrueSkill(npc, skill, skills[skill]);
-			endforeach
-
-
-			var happy := GetObjProperty(npc,"happiness"); //happiness do pet
-			var fiel := GetObjProperty(npc, "NeverRelease"); // se é animal fiel
-			if (happy)
-				SetObjProperty(npc,"happiness", happy -20);
-				if(happy < 10 )
-					if (!fiel) //destama se happiness menor que 10
-						SendSysMessage(owner, "*Seu pet "+npc.name+" decidiu que eh melhor ficar sozinho*");
-						destama(npc.serial);
-//					else // se é fiel só perde fidelidade
-//						SendSysMessage(owner, "*Seu pet "+npc.name+" nao sente mais tanta confian em voce**");
-//						EraseObjProperty(npc, "NeverRelease");
-//						EraseObjProperty(npc, "bond");
-					endif
-				endif
-			endif
-		
-			//Para repor as habs do despertar natureza do pet
-			var instincts := GetObjProperty(npc,"instincts");
-			var ferocidade := instincts["Ferocidade"].ins_name;
-			var fortaleza := instincts["Fortaleza"].ins_name;
-			var flexibilidade := instincts["Flexibilidade"].ins_name;
-			if (!instincts)
-			else
-				if (ferocidade == "Ferocidade")
-					AP_SetTrueStat(npc, STRENGTH, AP_GetStat(npc, STRENGTH) + 15);
-				endif
-				if (fortaleza == "Fortaleza")
-					var hits := CInt(AP_GetVitalMaximumValue(npc, "Hits"));
-					var variavel := Cint(hits / 3);
-					var variavel2 := Cint(variavel /2); //não sei pq ele duplica por isso a divisão pela metade
-					setObjProperty(npc, "hitsmod", variavel2);
-				endif
-				if (flexibilidade == "Flexibilidade")
-					AP_SetTrueStat(npc, DEXTERITY, AP_GetStat(npc, DEXTERITY) + 15);
-				endif
-			RecalcVitals(npc);
-			endif
-
+			var master := SystemFindObjectBySerial(ownerserial);
+			SendSysMessage(mobile, "Voce estabilizou o paciente.");
+			RessuscitarPet(targ, master, 1);
 		else
 			SendSysMessage(mobile, "Voce nao conseguiu estabilizar "+name+".");
 		endif
@@ -507,14 +444,6 @@ function GetHealingAmt(heal_skill, aux_skill)
 	var amt := Ceil(heal_skill + (aux_skill/2.0));
 	return amt;
 endfunction
-
-function CopyProps(origin, destiny)
-	var propnames := GetObjPropertyNames(origin);
-	foreach prop in propnames
-		SetObjPRoperty(destiny, prop, GetObjProperty(origin, prop));
-	endforeach
-endfunction
-
 
 function WaitCura(who, segundos)
 	var seconds := segundos;


### PR DESCRIPTION
…nado o Menu do Evil tb para padronização, refatorado função res_pet para o taming.inc .
Adicionar sysmsg nas ações de resurrect do pet fiel, talvez com tempo que vai acordar e etc;
Corrigido um bug ao utilizar o Despertar no Menu, tem um wait zoado ali, player tem q ficar 1 minuto com Menu HA aberto pra usar o despertar;
Corrigida descrições do Menu de despertar
No Ldj a hab "Espreita Selvagem" permitia fidelizar apenas +1 animal, mas in game tava filidelizando infinitos
Corrigido exploit de quando o pet fidelizado está pra dar ress e o player fideliza outra nesse interím para poder ter mais um fidelizado;
Refatorada função res_pet para inc, tá repetida e ocupando espaço em dois scripts diferentes (healing e npcdeath);