### PR TITLE
Gump de awareness substituído por interações com o cursor de alvo.

### DIFF
--- a/pkg/skills/awareness/awareness.src
+++ b/pkg/skills/awareness/awareness.src
@@ -20,60 +20,38 @@ program skill_Alertness(who)
 	EraseObjProperty(who, "#IsMeditating");
 	EraseObjProperty(who, "#IsWaiting");
 
-	var menu := choose(who);
-	if (menu == 1)
-		if (!examinarAlvo(who))
-			SendSysMessageEx(who, "Voce nao encontrou nada de diferente.", SSM_INFO);
-			return 1;
+	var deveCheckarLOS := 0;
+	var isLOS := 0;
+	var isEncontrado := 0;
+	var ignore := GetObjProperty(who, "IgnoreHidden");
+	SendSysMessageEx(who, "Selecione um alvo. Cancelar o alvo procurará algo em volta.", SSM_INFO);
+	SendSysMessageEx(who, "Selecionar a si mesmo Ativa ou Desativa a procura passiva. [Atual: {}]".format(ignore? "Ativado.": "Desativado."), SSM_INFO);
+	var targ := Target(who,TGTOPT_NOCHECK_LOS);
+
+	if (targ.isA(POLCLASS_MOBILE))
+		deveCheckarLOS := true;
+		isLOS := CheckLosBetween(who.x, who.y, who.z, targ.x, targ.y, targ.z, who.realm);
+		if(isLOS)
+			if(targ == who)
+				AtivaDesativaPassivo(who);
+				isEncontrado := 1;
+			else
+				isEncontrado := ExaminarMobile(who,targ);
+			endif
 		endif
-	elseif (menu == 2)
-		if(who.hidden)
-			SendSysMessageEx(who, "Procurando algo", SSM_INFO);
-		else
-			PrintTextAbove(who, "*Procurando algo*");
+	elseif(targ.isA(POLCLASS_CONTAINER) || targ.isA(POLCLASS_DOOR))
+		deveCheckarLOS := true;
+		isLOS := CheckLosBetween(who.x, who.y, who.z, targ.x, targ.y, targ.z, who.realm);
+		if(isLOS)
+			isEncontrado := ExaminarObjeto(who,targ);
 		endif
-		if ( !examinarArea(who) )
-			SendSysMessageEx(who, "Voce nao encontrou nada de diferente.", SSM_INFO);
-			return 1;
-		endif
+	elseif(targ == 0)
+		isEncontrado := ExaminarArea(who);
 	else
-		var ignore := GetObjProperty(who, "IgnoreHidden");
-		if (ignore)
-			SendSysMessageEx(who, "Modo Passivo Ligado. Procure e revela passivamente!", SSM_INFO);
-			EraseObjProperty(who, "IgnoreHidden");
-		else
-			SendSysMessageEx(who, "Modo Passivo Desligado. Percebe, mas não revela passivamente!", SSM_FAIL);
-			SetObjProperty(who, "IgnoreHidden", 1);
-		endif
+		SendSysMessageEx(who, "Alvo inválido.", SSM_FAIL);
+	endif
+
+	if(deveCheckarLOS && !isLOS)
+		SendSysMessageEx(who, "Você não enxerga o alvo.", SSM_FAIL);
 	endif
 endprogram
-
-function Choose(mobile)
-	var yn_gump := GFCreateGump(140, 100);
-
-	GFClosable(yn_gump, 0);
-	GFResizePic(yn_gump, 0, 0, GFCfgConst("Defaults", "BackGround"), 400, 180); //205);
-	GFResizePic(yn_gump, 15, 15, GFCfgConst("Defaults", "ForeGround"), 370, 150); //175);
-
-	var y_pos := 20;
-	GFTextLine(yn_gump, 20, y_pos, 1153, "Escolha uma opção.");
-	y_pos := y_pos+40;
-	GFAddButton(yn_gump, 20, (y_pos+3), 2117, 2118, GF_CLOSE_BTN, 1);
-	GFTextLine(yn_gump, 40, y_pos, 1153, "Examinar algo específico.");
-	y_pos := y_pos+40;
-	GFAddButton(yn_gump, 20, (y_pos+3), 2117, 2118, GF_CLOSE_BTN, 2);
-	GFTextLine(yn_gump, 40, y_pos, 1153, "Examinar a área que estou.");
-	y_pos := y_pos+40;
-	GFAddButton(yn_gump, 20, (y_pos+3), 2117, 2118, GF_CLOSE_BTN, 3);
-	var ignore := GetObjProperty(mobile, "IgnoreHidden");
-	var onoff := "Desligar";
-	if (ignore)
-		onoff := "Ligar";
-	endif
-
-	GFTextLine(yn_gump, 40, y_pos, 1153, onoff+" Passividade");
-
-	var input := GFSendGump(mobile, yn_gump);
-	input := input[0];
-	return input;
-endfunction

--- a/pkg/skills/awareness/awareness.src
+++ b/pkg/skills/awareness/awareness.src
@@ -25,7 +25,7 @@ program skill_Alertness(who)
 	var isEncontrado := 0;
 	var ignore := GetObjProperty(who, "IgnoreHidden");
 	SendSysMessageEx(who, "Selecione um alvo. Cancelar o alvo procurará algo em volta.", SSM_INFO);
-	SendSysMessageEx(who, "Selecionar a si mesmo Ativa ou Desativa a procura passiva. [Atual: {}]".format(ignore? "Ativado.": "Desativado."), SSM_INFO);
+	SendSysMessageEx(who, "Selecionar a si mesmo Ativa ou Desativa a procura passiva. [Atual: {}]".format(!ignore? "Ativado.": "Desativado."), SSM_INFO);
 	var targ := Target(who,TGTOPT_NOCHECK_LOS);
 
 	if (targ.isA(POLCLASS_MOBILE))
@@ -54,4 +54,5 @@ program skill_Alertness(who)
 	if(deveCheckarLOS && !isLOS)
 		SendSysMessageEx(who, "Você não enxerga o alvo.", SSM_FAIL);
 	endif
+	return;
 endprogram

--- a/pkg/skills/awareness/include/awareness.inc
+++ b/pkg/skills/awareness/include/awareness.inc
@@ -6,49 +6,41 @@ include ":traps:traps";
 include ":charactercreation:habilidades";
 
 
-function examinarAlvo(who)
-	SendSysMessageEx(who, "Selecione um alvo.", SSM_REQUEST);
-	var targ := Target(who);
-	if( !targ )
-		SendSysMessageEx(who, "Cancelado.", SSM_FAIL);
-		return 0;
-	elseif ( !targ.isA(POLCLASS_MOBILE) && !targ.isA(POLCLASS_CONTAINER) && !targ.isA(POLCLASS_DOOR) )
-		SendSysMessageEx(who, "Alvo invalido.", SSM_FAIL);
-		return 0;
+function ExaminarMobile(who,targ)
+	if (GetObjProperty(targ, "disfarce") )
+		if (SkillCheck(who, AWARENESS, AP_GetSkill(who, SNEAK)))
+			var char := GetObjProperty(targ, "chardata");
+			var name := char.FirstName;
+			var last_name := char.LastName;
+			if (last_name)
+				name := name+" "+last_name;
+			endif
+			sleep(1);
+			SendSysMessageEx(who, "Voce descobriu disfarce de "+name+" em "+targ.name+".", SSM_INFO);
+			SendSysMessageEx(who, "ATENCAO: Se voce nao conhece esse personagem, ignore o fato de saber o nome dele.", SSM_INFO);
+			return 1;
+		endif
 	endif
+	SendSysMessageEx(who, "Voce nao encontrou nada de diferente.", SSM_FAIL);
+	return 0;
+endfunction
+
+function ExaminarObjeto(who,targ)
 
 	var armadilhaRevelada := 0;
 	var acharamArmadilha := array;
-	var found := 0;
-	if(targ.isA(POLCLASS_MOBILE))
-		if (GetObjProperty(targ, "disfarce") )
-			if (SkillCheck(who, AWARENESS, AP_GetSkill(who, SNEAK)))
-				found:=1;
-				var char := GetObjProperty(targ, "chardata");
-				var name := char.FirstName;
-				var last_name := char.LastName;
-				if (last_name)
-					name := name+" "+last_name;
-				endif
-				sleep(1);
-				SendSysMessageEx(who, "Voce descobriu disfarce de "+name+" em "+targ.name+".", SSM_INFO);
-				SendSysMessageEx(who, "ATENCAO: Se voce nao conhece esse personagem, ignore o fato de saber o nome dele.", SSM_INFO);
-				return 1;
-			endif
-			return 0;
-		endif
-	elseif ( GetObjProperty(targ, "TrapList") )
+	if ( GetObjProperty(targ, "TrapList") )
 		sleep(1);
 		if(!ReserveItem(targ)) //Apenas um personagem examina o bau por vez.
 			SendSysMessageEx(who, "Alguem ja esta examinando "+targ.name+".", SSM_FAIL);
-	  		return 0;
-	  	else
-	  		if(who.hidden)
-	  			SendSysMessageEx(who, "Examinando "+targ.name+".", SSM_INFO);
+			return 0;
+		else
+			if(who.hidden)
+				SendSysMessageEx(who, "Examinando "+targ.name+".", SSM_INFO);
 			else
 				PrintTextAbove(who, "*Examinando "+targ.name+"*");
 			endif
-	  		sleep(1);
+			sleep(1);
 		endif
 		if(GetObjProperty(targ, "trapSpoted"))
 			armadilhaRevelada := GetObjProperty(targ, "trapSpoted"); //CPROP que diz quem revelou a trap pra todos
@@ -97,11 +89,7 @@ function examinarAlvo(who)
 				return 0;
 			endif
 		endif
-	else
-		SendSysMessageEx(who, "Voce nao encontrou nada de diferente.", SSM_INFO);
-		return 0;
 	endif
-	return 0;
 endfunction
 
 function CalculateDHDiff(who, mobile)
@@ -143,7 +131,13 @@ function CalculateDHDiff(who, mobile)
 
 endfunction
 
-function examinarArea(who)
+function ExaminarArea(who)
+	if(who.hidden)
+		SendSysMessageEx(who, "Procurando algo", SSM_INFO);
+	else
+		PrintTextAbove(who, "*Procurando algo*");
+	endif
+
 	var range := CInt( AP_GetSkill(who, AWARENESS) / 10 ) + 1;
 
 	if ( TemHabilidade(who, "Sempre Alerta") )
@@ -252,6 +246,17 @@ function ConvertIntToHex(astring, alength)
         astring := "0" + astring;
     endwhile
     return astring;
+endfunction
+
+function AtivaDesativaPassivo(who)
+	var ignore := GetObjProperty(who, "IgnoreHidden");
+	if (ignore)
+		SendSysMessageEx(who, "Modo Passivo Ligado. Procure e revela passivamente!", SSM_INFO);
+		EraseObjProperty(who, "IgnoreHidden");
+	else
+		SendSysMessageEx(who, "Modo Passivo Desligado. Percebe, mas não revela passivamente!", SSM_FAIL);
+		SetObjProperty(who, "IgnoreHidden", 1);
+	endif
 endfunction
 
 function DrawObject(ktowhom, kobj, kgraphic, kcolor)


### PR DESCRIPTION
O Gump de awareness foi removido. 

Ao invés disso, Secionar um mobile investiga o mobile,Selecionar um objeto - como portas e baús - tenta achar armadilhas nele, selecionar a si mesmo Ativa\Desativa a passiva e cancelar o cursor de alvo procura em volta do jogador. Tudo obedecendo as antigas regras estabelecidas.