### PR TITLE
fix/HabsArqueiros

### DIFF
--- a/pkg/systems/equipsys/commands/player/golpe.src
+++ b/pkg/systems/equipsys/commands/player/golpe.src
@@ -79,7 +79,7 @@ function canChangePostura(who, weapon)
 		return 0;
 	endif
 
-	if (elem.Attribute.Upper() == RANGED.Upper())
+	if (elem.Attribute == RANGED)
 		SendSysMessageEx(who, "Não é possível alterar postura de arma à distância.", SSM_FAIL);
 		return 0;
 	endif


### PR DESCRIPTION
fix .upper mudava o cache da config dos arcos. Removido.