### PR TITLE
Bugs XDoom - Magia Grimorio

### DIFF
--- a/pkg/systems/spells/config/allSpellsNotUsed.cfg
+++ b/pkg/systems/spells/config/allSpellsNotUsed.cfg
@@ -320,7 +320,7 @@ V
 #{
 #
 #	RitualId 	1
-#	Name		Invocar Espirito do Fogo
+#	Name		Invoc. Espirito do Fogo
 #	RitualScript	spells/rituals/invocarfogo
 #
 #	Desc           	Invoca um elemental do fogo.
@@ -590,7 +590,7 @@ V
 ## Spell 13
 #{
 #	# SpellId		13
-#	Name		Invocar Espirito
+#	Name		Invoc. Espirito
 #	SpellScript	:spells:spell_logic/necromancer/invocarespirito
 #
 #	Target         Area
@@ -1478,7 +1478,7 @@ V
 # # Spell 4
 # {
 # 	# SpellId		4
-# 	Name		Ataque elemental/ Fogo
+# 	Name		Ataque elem. Fogo
 # 	SpellScript	:spells:spell_logic/swordmage/ataquefogo
 # 
 # 	Target         Unico
@@ -1498,7 +1498,7 @@ V
 # # Spell 5
 # {
 # 	# SpellId		5
-# 	Name		Ataque elemental/ Energia
+# 	Name		Ataque elem. Energia
 # 	SpellScript	:spells:spell_logic/swordmage/ataqueenergia
 # 
 # 	Target         Unico
@@ -1517,7 +1517,7 @@ V
 # # Spell 6
 # {
 # 	# SpellId		6
-# 	Name		Ataque Elemental/ Gelo
+# 	Name		Ataque elem. Gelo
 # 	SpellScript	:spells:spell_logic/swordmage/ataquegelo
 # 
 # 	Target         Unico
@@ -1536,7 +1536,7 @@ V
 # # Spell 7
 # {
 # 	# SpellId		7
-# 	Name		Circulo de Devastacao/ Fogo
+# 	Name		Circ. Devast. Fogo
 # 	SpellScript	:spells:spell_logic/swordmage/circulodevasfogo
 # 
 # 	Target         Unico
@@ -1556,7 +1556,7 @@ V
 # # Spell 8
 # {
 # 	# SpellId		8
-# 	Name		Circulo de Devastacao/ Gelo
+# 	Name		Circ. Devast. Gelo
 # 	SpellScript	:spells:spell_logic/swordmage/circulodevasgelo
 # 
 # 	Target         Unico
@@ -1576,7 +1576,7 @@ V
 # # Spell 9
 # {
 # 	# SpellId		9
-# 	Name		Circulo de Devastacao/ Energia
+# 	Name		Circ. Devast. Energia
 # 	SpellScript	:spells:spell_logic/swordmage/circulodevasenergia
 # 
 # 	Target         Unico
@@ -3104,7 +3104,7 @@ V
 # # Spell 15
 # {
 # 	# SpellId		15
-# 	Name		Pacto com a Sepultura
+# 	Name		Pacto Sepultura
 # 	Type		Necromancer
 # 	SpellScript	/:spells:spell_logic/necromancer/pactosepultura
 # 
@@ -3194,7 +3194,7 @@ V
 ## Spell 19
 #{
 #	# SpellId		19
-#	Name		Invocar Espirito
+#	Name		Invoc. Espirito
 #	Type		Necromancer
 #	SpellScript	/:spells:spell_logic/necromancer/invocarespirito
 #
@@ -3553,7 +3553,7 @@ V
 ## Spell 36
 #{
 #	# SpellId		36
-#	Name		Ataque elemental/ Fogo
+#	Name		Ataque elem. Fogo
 #	SpellScript	/:spells:spell_logic/swordmage/ataquefogo
 #	Type		Swordmage
 #
@@ -3571,7 +3571,7 @@ V
 ## Spell 37
 #{
 #	# SpellId		37
-#	Name		Ataque elemental/ Energia
+#	Name		Ataque elem. Energia
 #	SpellScript	/:spells:spell_logic/swordmage/ataqueenergia
 #	Type		Swordmage
 #
@@ -3589,7 +3589,7 @@ V
 ## Spell 38
 #{
 #	# SpellId		38
-#	Name		Ataque Elemental/ Gelo
+#	Name		Ataque elem. Gelo
 #	SpellScript	/:spells:spell_logic/swordmage/ataquegelo
 #	Type		Swordmage
 #
@@ -3607,7 +3607,7 @@ V
 ## Spell 39
 #{
 #	# SpellId		39
-#	Name		Circulo de Devastacao/ Fogo
+#	Name		Circ. Devast. Fogo
 #	SpellScript	/:spells:spell_logic/swordmage/circulodevasfogo
 #	Type		Swordmage
 #
@@ -3625,7 +3625,7 @@ V
 ## Spell 40
 #{
 #	# SpellId		40
-#	Name		Circulo de Devastacao/ Gelo
+#	Name		Circ. Devast. Gelo
 #	SpellScript	/:spells:spell_logic/swordmage/circulodevasgelo
 #	Type		Swordmage
 #
@@ -3643,7 +3643,7 @@ V
 ## Spell 41
 #{
 #	# SpellId		41
-#	Name		Circulo de Devastacao/ Energia
+#	Name		Circ. Devast. Energia
 #	SpellScript	/:spells:spell_logic/swordmage/circulodevasenergia
 #	Type		Swordmage
 #
@@ -4327,7 +4327,7 @@ V
 ### Spell 75
 ##{
 ##	# SpellId 75
-##	Name	Invocar Espirito do Urso
+##	Name	Invoc. Espirito do Urso
 ##	SpellScript   :spells:spell_logic/druid/summon
 ##	Type		Totem
 ##	Circle		1
@@ -4348,7 +4348,7 @@ V
 ## Spell 76
 #{
 #	# SpellId 76
-#	Name	Invocar Espirito da Luz
+#	Name	Invoc. Espirito da Luz
 #	SpellScript   :spells:spell_logic/druid/summon
 #	Type		Totem
 #	Circle		1
@@ -4368,7 +4368,7 @@ V
 ## Spell 77
 #{
 #	# SpellId 77
-#	Name	Invocar Espirito do Lobo
+#	Name	Invoc. Espirito do Lobo
 #	SpellScript   :spells:spell_logic/druid/summon
 #	Type		Totem
 #	Circle		1
@@ -4388,7 +4388,7 @@ V
 ## Spell 78
 #{
 #	# SpellId 78
-#	Name	Invocar Espirito da Serpente
+#	Name	Invoc. Espirito da Serpente
 #	SpellScript   :spells:spell_logic/druid/summon
 #	Type		Totem
 #	Circle		1
@@ -4409,7 +4409,7 @@ V
 ## Spell 79
 #{
 #	# SpellId 79
-#	Name	Invocar Espirito da Pantera
+#	Name	Invoc. Espirito da Pantera
 #	SpellScript   :spells:spell_logic/druid/summon
 #	Type		Totem
 #	Circle		1
@@ -4429,7 +4429,7 @@ V
 ## Spell 80
 #{
 #	# SpellId 80
-#	Name	Invocar Espirito da Cura
+#	Name	Invoc. Espirito da Cura
 #	SpellScript   :spells:spell_logic/druid/summon
 #	Type		Totem
 #	Circle		1
@@ -4449,7 +4449,7 @@ V
 ## Spell 81
 #{
 #	# SpellId 81
-#	Name	Invocar Driade
+#	Name	Invoc. Driade
 #	SpellScript   :spells:spell_logic/druid/summon
 #	Type		Totem
 #	Circle		1
@@ -4469,7 +4469,7 @@ V
 ## Spell 82
 #{
 #	# SpellId 82
-#	Name	Invocar Ent
+#	Name	Invoc. Ent
 #	SpellScript   :spells:spell_logic/druid/summon
 #	Type		Totem
 #	Circle		1
@@ -4747,7 +4747,7 @@ V
 ## Spell 93
 #{
 #	# SpellId 93
-#	Name	Invocar Espirito do Fogo
+#	Name	Invoc. Espirito do Fogo
 #	SpellScript   :spells:spell_logic/druid/summon
 #	Type		Totem
 #	Circle		2
@@ -4767,7 +4767,7 @@ V
 ## Spell 94
 #{
 #	# SpellId 94
-#	Name	Invocar Colosso
+#	Name	Invoc. Colosso
 #	SpellScript   :spells:spell_logic/druid/summon
 #	Type		Totem
 #	Circle		3

--- a/pkg/systems/spells/config/allspells.cfg
+++ b/pkg/systems/spells/config/allspells.cfg
@@ -329,7 +329,7 @@ Spell 14
 Spell 15
 {
 	SpellId		15
-	Name		Pacto com a Sepultura
+	Name		Pacto Sepultura
 	Type		Necromancer
 	SpellScript	:spells:necromancer/pactosepultura
 
@@ -419,7 +419,7 @@ Spell 18
 Spell 19
 {
 	SpellId		19
-	Name		Invocar Espirito
+	Name		Invoc. Espirito
 	Type		Necromancer
 	SpellScript	:spells:necromancer/invocarespirito
 
@@ -778,7 +778,7 @@ Spell 35
 Spell 36
 {
 	SpellId		36
-	Name		Ataque elemental: Fogo
+	Name		Ataque elem. Fogo
 	SpellScript	:spells:swordmage/ataquefogo
 	Type		Swordmage
 
@@ -796,7 +796,7 @@ Spell 36
 Spell 37
 {
 	SpellId		37
-	Name		Ataque elemental: Energia
+	Name		Ataque elem. Energia
 	SpellScript	:spells:swordmage/ataqueenergia
 	Type		Swordmage
 
@@ -814,7 +814,7 @@ Spell 37
 Spell 38
 {
 	SpellId		38
-	Name		Ataque Elemental: Gelo
+	Name		Ataque elem. Gelo
 	SpellScript	:spells:swordmage/ataquegelo
 	Type		Swordmage
 
@@ -832,7 +832,7 @@ Spell 38
 Spell 39
 {
 	SpellId		39
-	Name		Circulo de Devastacao: Fogo
+	Name		Circ. Devast. Fogo
 	SpellScript	:spells:swordmage/circulodevasfogo
 	Type		Swordmage
 
@@ -850,7 +850,7 @@ Spell 39
 Spell 40
 {
 	SpellId		40
-	Name		Circulo de Devastacao: Gelo
+	Name		Circ. Devast. Gelo
 	SpellScript	:spells:swordmage/circulodevasgelo
 	Type		Swordmage
 
@@ -868,7 +868,7 @@ Spell 40
 Spell 41
 {
 	SpellId		41
-	Name		Circulo de Devastacao: Energia
+	Name		Circ. Devast. Energia
 	SpellScript	:spells:swordmage/circulodevasenergia
 	Type		Swordmage
 
@@ -1187,7 +1187,7 @@ Spell 56
 Spell 57
 {
 	SpellId 57
-	Name	Resistencia contra Energia
+	Name	Resistencia Energia
 	SpellScript  :spells:priest/protecaoenergia
 	Type		Priest
 	Circle		1
@@ -1205,7 +1205,7 @@ Spell 57
 Spell 58
 {
 	SpellId 58
-	Name	Resistencia contra Veneno
+	Name	Resistencia Veneno
 	SpellScript  :spells:priest/protecaoveneno
 	Type		Priest
 	Circle		1
@@ -1552,7 +1552,7 @@ Spell 74
 Spell 75
 {
 	SpellId 75
-	Name	Invocar Espirito do Urso
+	Name	Invoc. Espir. Urso
 	SpellScript  :spells:totemista/summon
 	Type		Totem
 	Circle		1
@@ -1573,7 +1573,7 @@ Spell 75
 Spell 76
 {
 	SpellId 76
-	Name	Invocar Espirito da Luz
+	Name	Invoc. Espir. Luz
 	SpellScript  :spells:totemista/summon
 	Type		Totem
 	Circle		1
@@ -1593,7 +1593,7 @@ Spell 76
 Spell 77
 {
 	SpellId 77
-	Name	Invocar Espirito do Lobo
+	Name	Invoc. Espir. Lobo
 	SpellScript  :spells:totemista/summon
 	Type		Totem
 	Circle		1
@@ -1613,7 +1613,7 @@ Spell 77
 Spell 78
 {
 	SpellId 78
-	Name	Invocar Espirito da Serpente
+	Name	Invoc. Espir. Serpente
 	SpellScript  :spells:totemista/summon
 	Type		Totem
 	Circle		1
@@ -1634,7 +1634,7 @@ Spell 78
 Spell 79
 {
 	SpellId 79
-	Name	Invocar Espirito da Pantera
+	Name	Invoc. Espir. Pantera
 	SpellScript  :spells:totemista/summon
 	Type		Totem
 	Circle		1
@@ -1654,7 +1654,7 @@ Spell 79
 Spell 80
 {
 	SpellId 80
-	Name	Invocar Espirito da Cura
+	Name	Invoc. Espir. Cura
 	SpellScript  :spells:totemista/summon
 	Type		Totem
 	Circle		1
@@ -1674,7 +1674,7 @@ Spell 80
 Spell 81
 {
 	SpellId 81
-	Name	Invocar Driade
+	Name	Invoc. Driade
 	SpellScript  :spells:totemista/summon
 	Type		Totem
 	Circle		1
@@ -1694,7 +1694,7 @@ Spell 81
 Spell 82
 {
 	SpellId 82
-	Name	Invocar Ent
+	Name	Invoc. Ent
 	SpellScript  :spells:totemista/summon
 	Type		Totem
 	Circle		1
@@ -1742,7 +1742,7 @@ Spell 83
 Spell 84
 {
 	SpellId 84
-	Name	Forma do Grande Urso
+	Name	Forma Grande Urso
 	SpellScript  :spells:totemista/polymorph
 	Type		Totem
 	Circle		1
@@ -1972,7 +1972,7 @@ Spell 92
 Spell 93
 {
 	SpellId 93
-	Name	Invocar Espirito do Fogo
+	Name	Invoc. Espir. Fogo
 	SpellScript  :spells:totemista/summon
 	Type		Totem
 	Circle		2
@@ -1992,7 +1992,7 @@ Spell 93
 Spell 94
 {
 	SpellId 94
-	Name	Invocar Colosso
+	Name	Invoc. Colosso
 	SpellScript  :spells:totemista/summon
 	Type		Totem
 	Circle		3

--- a/pkg/systems/spells/config/priestspells.cfg
+++ b/pkg/systems/spells/config/priestspells.cfg
@@ -263,7 +263,7 @@ Cycles        1
 Spell 4
 {
 SpellId 4
-Name    Resistencia contra Energia
+Name    Resistencia Energia
 PowerWords    Resistentia Energiae
 SpellScript  :spells:spell_logic/priest/protecaoenergia
 Type        Priest
@@ -282,7 +282,7 @@ Cycles        1
 Spell 5
 {
 SpellId 5
-Name    Resistencia contra Veneno
+Name    Resistencia Veneno
 PowerWords    Resistentia venenum
 SpellScript  :spells:spell_logic/priest/protecaoveneno
 Type        Priest

--- a/pkg/systems/spells/config/spellcaster.cfg
+++ b/pkg/systems/spells/config/spellcaster.cfg
@@ -42,7 +42,7 @@
 # SpellId: 27 | Name: Drenar Folego
 # SpellId: 29 | Name: Ampliar Dor
 # SpellId: 32 | Name: Correntes de dor
-# SpellId: 33 | Name: Pacto com a Sepultura
+# SpellId: 33 | Name: Pacto Sepultura
 # SpellId: 34 | Name: Atrasar Magias
 # SpellId: 35 | Name: Fuga de Mana
 # SpellId: 39 | Name: Sonho Macabro
@@ -57,7 +57,7 @@
 # SpellId: 49 | Name: Horror Paralisante
 # SpellId: 50 | Name: Maldicao de Zhao
 # SpellId: 54 | Name: Levantar os Mortos
-# SpellId: 55 | Name: Invocar Espirito
+# SpellId: 55 | Name: Invoc. Espir. 
 # SpellId: 56 | Name: Nuvem Acida
 # SpellId: 57 | Name: Envenenar
 # SpellId: 58 | Name: Envenenar Espirito
@@ -85,12 +85,12 @@
 # SpellId: 67 | Name: Lamina Flamejante
 # SpellId: 68 | Name: Lamina de Gelo
 # SpellId: 69 | Name: Lamina Eletrica
-# SpellId: 70 | Name: Ataque Elemental/Fogo
-# SpellId: 71 | Name: Ataque Elemental/Energia
-# SpellId: 72 | Name: Ataque Elemental/Gelo
-# SpellId: 73 | Name: Circulo de Devastacao/Fogo
-# SpellId: 74 | Name: Circulo de Devastacao/Gelo
-# SpellId: 75 | Name: Circulo de Devastacao/Energia
+# SpellId: 70 | Name: Ataque elem. Fogo
+# SpellId: 71 | Name: Ataque elem. Energia
+# SpellId: 72 | Name: Ataque elem. Gelo
+# SpellId: 73 | Name: Circ. Devast. Fogo
+# SpellId: 74 | Name: Circ. Devast. Gelo
+# SpellId: 75 | Name: Circ. Devast. Energia
 # SpellId: 76 | Name: Pandemonio Infernal
 # SpellId: 77 | Name: Canalizar Tempestade
 # SpellId: 78 | Name: Furia Glacial
@@ -106,22 +106,22 @@
 # SpellId: 89 | Name: Encantar Objeto
 
 # Druid Spells:
-# SpellId: 11 | Name: Invocar Espirito do Urso
-# SpellId: 12 | Name: Invocar Espirito da Luz
-# SpellId: 13 | Name: Invocar Espirito do Lobo
-# SpellId: 14 | Name: Invocar Espirito da Serpente
-# SpellId: 15 | Name: Invocar Espirito da Pantera
-# SpellId: 16 | Name: Invocar Espirito da Cura
-# SpellId: 17 | Name: Invocar Driade
-# SpellId: 18 | Name: Invocar Ent
+# SpellId: 11 | Name: Invoc. Espir.  Urso
+# SpellId: 12 | Name: Invoc. Espir.  Luz
+# SpellId: 13 | Name: Invoc. Espir.  Lobo
+# SpellId: 14 | Name: Invoc. Espir.  Serpente
+# SpellId: 15 | Name: Invoc. Espir.  Pantera
+# SpellId: 16 | Name: Invoc. Espir.  Cura
+# SpellId: 17 | Name: Invoc. Driade
+# SpellId: 18 | Name: Invoc. Ent
 # SpellId: 19 | Name: Forma de Urso
 # SpellId: 20 | Name: Forma do Grande Urso
 # SpellId: 21 | Name: Forma do Lobo
 # SpellId: 22 | Name: Forma da Serpente
 # SpellId: 23 | Name: Forma da Pantera
 # SpellId: 24 | Name: Forma Licantropa
-# SpellId: 45 | Name: Invocar Espirito do Fogo
-# SpellId: 60 | Name: Invocar Colosso
+# SpellId: 45 | Name: Invoc. Espir. Fogo
+# SpellId: 60 | Name: Invoc. Colosso
 
 # Time Mage Spells:
 # SpellId: 61 | Name: Velocidade
@@ -129,7 +129,7 @@
 # SpellId: 63 | Name: Teleportar
 
 # Ritual Spells:
-# SpellId: 45 | Name: Invocar Espirito do Fogo
+# SpellId: 45 | Name: Invoc. Espir.  Fogo
 # SpellId: 25 | Name: Aprisionar Alma
 ##############################################################
 Spell 1
@@ -366,7 +366,7 @@ Spell 10
 Spell 11
 {
     SpellId        11
-	Name	Invocar Espirito do Urso
+	Name	Invoc. Espir. Urso
 	SpellScript  :spells:spell_logic/druid/summon
 	School		Aradalore
     Type		spellcaster
@@ -387,7 +387,7 @@ Spell 11
 Spell 12
 {
     SpellId        12
-	Name	Invocar Espirito da Luz
+	Name	Invoc. Espir. Luz
 	SpellScript  :spells:spell_logic/druid/summon
 	School		Aradalore
     Type		spellcaster
@@ -408,7 +408,7 @@ Spell 12
 Spell 13
 {
     SpellId        13
-	Name	Invocar Espirito do Lobo
+	Name	Invoc. Espir. Lobo
 	SpellScript  :spells:spell_logic/druid/summon
 	School		Aradalore
     Type		spellcaster
@@ -429,7 +429,7 @@ Spell 13
 Spell 14
 {
     SpellId        14
-	Name	Invocar Espirito da Serpente
+	Name	Invoc. Espir. Serpente
 	SpellScript  :spells:spell_logic/druid/summon
 	School		Aradalore
     Type		spellcaster
@@ -450,7 +450,7 @@ Spell 14
 Spell 15
 {
     SpellId        15
-	Name	Invocar Espirito da Pantera
+	Name	Invoc. Espir. Pantera
 	SpellScript  :spells:spell_logic/druid/summon
 	School		Aradalore
     Type		spellcaster
@@ -471,7 +471,7 @@ Spell 15
 Spell 16
 {
     SpellId        16
-	Name	Invocar Espirito da Cura
+	Name	Invoc. Espir. Cura
 	SpellScript  :spells:spell_logic/druid/summon
 	School		Aradalore
     Type		spellcaster
@@ -492,7 +492,7 @@ Spell 16
 Spell 17
 {
     SpellId        17
-	Name	Invocar Driade
+	Name	Invoc. Driade
 	SpellScript  :spells:spell_logic/druid/summon
 	School		Aradalore
     Type		spellcaster
@@ -513,7 +513,7 @@ Spell 17
 Spell 18
 {
     SpellId        18
-	Name	Invocar Ent
+	Name	Invoc. Ent
 	SpellScript  :spells:spell_logic/druid/summon
 	School		Aradalore
     Type		spellcaster
@@ -563,7 +563,7 @@ Spell 19
 Spell 20
 {
     SpellId        20
-	Name	Forma do Grande Urso
+	Name	Forma Grande Urso
 	SpellScript  :spells:spell_logic/druid/polymorph
 	School		Aradalore
     Type		spellcaster
@@ -895,7 +895,7 @@ Spell 32
 Spell 33
 {
     SpellId        33
-	Name		Pacto com a Sepultura
+	Name		Pacto Sepultura
 	School		Kaijin
     Type		spellcaster
 	SpellScript	:spells:spell_logic/necromancer/pactosepultura
@@ -1164,7 +1164,7 @@ Spell 44
 Spell 45
 {
     SpellId        45
-	Name	Invocar Espirito do Fogo
+	Name	Invoc. Espir. Fogo
 	SpellScript  :spells:spell_logic/druid/summon
 	School		Aradalore
     Type		spellcaster
@@ -1392,7 +1392,7 @@ Spell 54
 Spell 55
 {
     SpellId        55
-	Name		Invocar Espirito
+	Name		Invoc. Espirito 
 	School		Kaijin
     Type		spellcaster
 	SpellScript	:spells:spell_logic/necromancer/invocarespirito
@@ -1503,7 +1503,7 @@ Spell 59
 Spell 60
 {
     SpellId        60
-	Name	Invocar Colosso
+	Name	Invoc. Colosso
 	SpellScript  :spells:spell_logic/druid/summon
 	School		Aradalore
     Type		spellcaster
@@ -1712,7 +1712,7 @@ Spell 69
 Spell 70
 {
     SpellId        70
-	Name		Ataque elemental/ Fogo
+	Name		Ataque elem. Fogo
 	SpellScript	:spells:spell_logic/swordmage/ataquefogo
 	School		Ahtaleloreth
     Type		spellcaster
@@ -1732,7 +1732,7 @@ Spell 70
 Spell 71
 {
     SpellId        71
-	Name		Ataque elemental/ Energia
+	Name		Ataque elem. Energia
 	SpellScript	:spells:spell_logic/swordmage/ataqueenergia
 	School		Ahtaleloreth
     Type		spellcaster
@@ -1752,7 +1752,7 @@ Spell 71
 Spell 72
 {
     SpellId        72
-	Name		Ataque Elemental/ Gelo
+	Name		Ataque elem. Gelo
 	SpellScript	:spells:spell_logic/swordmage/ataquegelo
 	School		Ahtaleloreth
     Type		spellcaster
@@ -1772,7 +1772,7 @@ Spell 72
 Spell 73
 {
     SpellId        73
-	Name		Circulo de Devastacao/ Fogo
+	Name		Circ. Devast. Fogo
 	SpellScript	:spells:spell_logic/swordmage/circulodevasfogo
 	School		Ahtaleloreth
     Type		spellcaster
@@ -1792,7 +1792,7 @@ Spell 73
 Spell 74
 {
     SpellId        74
-	Name		Circulo de Devastacao/ Gelo
+	Name		Circ. Devast. Gelo
 	SpellScript	:spells:spell_logic/swordmage/circulodevasgelo
 	School		Ahtaleloreth
     Type		spellcaster
@@ -1812,7 +1812,7 @@ Spell 74
 Spell 75
 {
     SpellId        75
-	Name		Circulo de Devastacao/ Energia
+	Name		Circ. Devast. Energia
 	SpellScript	:spells:spell_logic/swordmage/circulodevasenergia
 	School		Ahtaleloreth
     Type		spellcaster

--- a/pkg/systems/spells/grimorio.src
+++ b/pkg/systems/spells/grimorio.src
@@ -116,16 +116,37 @@ function copyrecipe( who, recipe )
   endif
 endfunction
 
-function CreateBookGump( book, who )
-  var rune_list := GetObjProperty( book, "spells" );
-  if ( TypeOf( rune_list ) != "Array" )
-	rune_list := array{};
-	SetObjProperty( book, "spells", rune_list );
-  endif
 
-  var book_gump := GFCreateGump();
-  // Begin Page 0 Setup
-  GFGumpPic( book_gump, 100, 10, 2200 );
+function GetNextThreshold(current_skill)
+    if (current_skill < 45)
+        return 45;
+    elseif (current_skill < 50)
+        return 50;
+    elseif (current_skill < 55)
+        return 55;
+    elseif (current_skill < 60)
+        return 60;
+    elseif (current_skill < 70)
+        return 70;
+    elseif (current_skill < 80)
+        return 80;
+    elseif (current_skill < 90)
+        return 90;
+    else
+        return 100;
+    endif
+endfunction
+
+
+function CreateBookGump( book, who )
+    var rune_list := GetObjProperty( book, "spells" );
+    if ( TypeOf( rune_list ) != "Array" )
+        rune_list := array{};
+        SetObjProperty( book, "spells", rune_list );
+    endif
+
+    var book_gump := GFCreateGump();
+GFGumpPic( book_gump, 100, 10, 2200 );
   GFGumpPic( book_gump, 125, 50, 57 );
   GFGumpPic( book_gump, 145, 50, 58 );
   GFGumpPic( book_gump, 160, 50, 58 );
@@ -143,31 +164,71 @@ function CreateBookGump( book, who )
   GFGumpPic( book_gump, 385, 50, 58 );
   GFGumpPic( book_gump, 395, 50, 59 );
 
-  /* GFAddButton(book_gump, 130, 187, 2225, 2225, GF_PAGE_BTN, 2);
-	GFAddButton(book_gump, 165, 187, 2226, 2226, GF_PAGE_BTN, 3);
-	GFAddButton(book_gump, 200, 187, 2227, 2227, GF_PAGE_BTN, 4);
-	GFAddButton(book_gump, 235, 187, 2228, 2228, GF_PAGE_BTN, 5);
-	GFAddButton(book_gump, 300, 187, 2229, 2229, GF_PAGE_BTN, 6);
-	GFAddButton(book_gump, 335, 187, 2230, 2230, GF_PAGE_BTN, 7);
-	GFAddButton(book_gump, 370, 187, 2231, 2231, GF_PAGE_BTN, 8);
-	GFAddButton(book_gump, 405, 187, 2232, 2232, GF_PAGE_BTN, 9); */
-  // GFHTMLArea(book_gump,  140, 40, 80, 18, "Charges:");
-  // GFHTMLArea(book_gump,  300, 40, 100, 18, "Max Charges:");
-  // GFHTMLArea(book_gump,  220, 40, 80, 18, charges);
-  // GFHTMLArea(book_gump,  400, 40, 100, 18, max_charges);
-  // End Page 0 Setup
+    GFGumpPic( book_gump, 100, 10, 2200 );
 
-  // Begin Page 1 Setup
-  GFPage( book_gump, 1 );
-  // GFAddButton(book_gump, 125, 15, 2472, 2473, GF_CLOSE_BTN, 50);
-  if ( GetObjProperty( book, "NecroBook" ) )
-	GFHTMLArea( book_gump, 135, 22, 100, 18, "Livro de Necromancer" );
-  elseif ( GetObjProperty( book, "SangriaBook" ) )
-	GFHTMLArea( book_gump, 135, 22, 100, 18, "Livro da Magia" );
-  else
-	GFHTMLArea( book_gump, 135, 22, 100, 18, "Livro da Magia" );
-  endif
+    // Begin Page 1 Setup
+    GFPage( book_gump, 1 );
+	// Barra decorativa inicial
+GFGumpPic( book_gump, 125, 50, 57 );
+GFGumpPic( book_gump, 145, 50, 58 );
+GFGumpPic( book_gump, 160, 50, 58 );
+GFGumpPic( book_gump, 175, 50, 58 );
+GFGumpPic( book_gump, 190, 50, 58 );
+GFGumpPic( book_gump, 205, 50, 58 );
+GFGumpPic( book_gump, 220, 50, 58 );
+GFGumpPic( book_gump, 230, 50, 59 );
+GFGumpPic( book_gump, 290, 50, 57 );
+GFGumpPic( book_gump, 310, 50, 58 );
+GFGumpPic( book_gump, 325, 50, 58 );
+GFGumpPic( book_gump, 340, 50, 58 );
+GFGumpPic( book_gump, 355, 50, 58 );
+GFGumpPic( book_gump, 370, 50, 58 );
+GFGumpPic( book_gump, 385, 50, 58 );
+GFGumpPic( book_gump, 395, 50, 59 );
+    if ( GetObjProperty( book, "NecroBook" ) )
+        GFHTMLArea( book_gump, 135, 22, 100, 18, "Livro de Necromancer" );
+    elseif ( GetObjProperty( book, "SangriaBook" ) )
+        GFHTMLArea( book_gump, 135, 22, 100, 18, "Livro da Magia" );
+    else
+        GFHTMLArea( book_gump, 135, 22, 100, 18, "Livro da Magia" );
+    endif
 
+    // Adiciona informação de limite de pergaminhos
+    var chardata := GetObjProperty(who, "chardata");
+    var mlore := CInt(AP_GetSkill(who, MAGICLORE));
+    var max_text;
+
+    if (chardata.magia == "spellcaster")
+    // Calcula o máximo de pergaminhos baseado na skill
+    var max_scrolls := 8;
+    if (mlore >= 100)
+        max_scrolls := 16;
+    elseif (mlore >= 90)
+        max_scrolls := 15;
+    elseif (mlore >= 80)
+        max_scrolls := 14;
+    elseif (mlore >= 70)
+        max_scrolls := 13;
+    elseif (mlore >= 60)
+        max_scrolls := 12;
+    elseif (mlore >= 55)
+        max_scrolls := 11;
+    elseif (mlore >= 50)
+        max_scrolls := 10;
+    elseif (mlore >= 45)
+        max_scrolls := 9;
+    endif
+    
+    var current_scrolls := rune_list.Size();
+    max_text := "Perg = " + current_scrolls + "/" + max_scrolls;
+    max_text += "<br>Máx = 16";
+else
+    var current_scrolls := rune_list.Size();
+    max_text := "Pergaminhos = " + current_scrolls + "/8";
+    max_text += "<br>Máx = 8";
+endif
+
+GFHTMLArea(book_gump, 290, 22, 150, 40, max_text);
   GFAddButton( book_gump, 393, 14, 2206, 2206, GF_PAGE_BTN, 2 );
 
   if ( rune_list[1] )
@@ -231,14 +292,32 @@ function CreateBookGump( book, who )
   var rune_pos := 1;
 
   for i := 2 to 9
-	GFPage( book_gump, i );
-	GFAddButton( book_gump, 125, 14, 2205, 2205, GF_PAGE_BTN, ( i - 1 ) );
-	if ( i != 9 )
-	  GFAddButton( book_gump, 393, 14, 2206, 2206, GF_PAGE_BTN, ( i + 1 ) );
-	endif
+    GFPage( book_gump, i );
+    GFAddButton( book_gump, 125, 14, 2205, 2205, GF_PAGE_BTN, ( i - 1 ) );
+    if ( i != 9 )
+        GFAddButton( book_gump, 393, 14, 2206, 2206, GF_PAGE_BTN, ( i + 1 ) );
+    endif
 
-	var rune_entry := rune_list[rune_pos];
-	WritespellInfo( who, rune_entry );
+    // Adiciona barras decorativas na página interna
+    GFGumpPic( book_gump, 125, 50, 57 );
+    GFGumpPic( book_gump, 145, 50, 58 );
+    GFGumpPic( book_gump, 160, 50, 58 );
+    GFGumpPic( book_gump, 175, 50, 58 );
+    GFGumpPic( book_gump, 190, 50, 58 );
+    GFGumpPic( book_gump, 205, 50, 58 );
+    GFGumpPic( book_gump, 220, 50, 58 );
+    GFGumpPic( book_gump, 230, 50, 59 );
+    GFGumpPic( book_gump, 290, 50, 57 );
+    GFGumpPic( book_gump, 310, 50, 58 );
+    GFGumpPic( book_gump, 325, 50, 58 );
+    GFGumpPic( book_gump, 340, 50, 58 );
+    GFGumpPic( book_gump, 355, 50, 58 );
+    GFGumpPic( book_gump, 370, 50, 58 );
+    GFGumpPic( book_gump, 385, 50, 58 );
+    GFGumpPic( book_gump, 395, 50, 59 );
+
+    var rune_entry := rune_list[rune_pos];
+    WritespellInfo( who, rune_entry );
 	rune_entry.description := "<BASEFONT COLOR=#000066>" + cstr( rune_entry.description )
 															  + "<br>" + cstr( rune_entry.flavortext ) + "<br> <BASEFONT COLOR=#330000> Componentes Materiais: <br> ";
 	var regkeys := rune_entry.reagents.keys();

--- a/pkg/systems/spells/grimorio.src
+++ b/pkg/systems/spells/grimorio.src
@@ -25,7 +25,7 @@ program book( who, book )
   var donoGrimorio := GetObjProperty( book, "serialDono" );
   if ( donoGrimorio )
 	if ( donoGrimorio != who.serial )
-	  SendSysMessageEx( who, "Voce nao entende esse livro.", SSM_FAIL );
+	  SendSysMessageEx( who, "Esse livro tem dono e foi escrito de uma forma que você não entende", SSM_FAIL );
 	  return 0;
 	endif
   else
@@ -247,64 +247,67 @@ function CreateBookGump( book, who )
 															r )] ) + "<br>";
 	endforeach
 	rune_entry.description := rune_entry.description + "Mana: " + rune_entry.mana;
-	if ( TypeOf( rune_entry ) == "Struct" )
-	  if ( rune_entry.name )
-		// This puts the rune in page 1's list.
-		GFPage( book_gump, 1 );
-		GFTextCrop( book_gump, pOX, pOY, 115, 17, 995, rune_entry.name );
-		GFPage( book_gump, i );
+if ( TypeOf( rune_entry ) == "Struct" )
+  if ( rune_entry.name )
+    // This puts the rune in page 1's list.
+    GFPage( book_gump, 1 );
+    GFTextCrop( book_gump, pOX, pOY, 115, 17, 995, rune_entry.name );  // Mantém original aqui
+    
+    GFPage( book_gump, i );
 
-		// GFHTMLArea(book_gump, 160, 15, 100, 18, rune_entry.name);
-		GFTextCrop( book_gump, 160, 15, 100, 18, 995, rune_entry.name );
-		if ( TemHabilidade( who, "Escrever Pergaminhos" ) )
-		  GFTextCrop( book_gump, 180, 35, 100, 18, 995, "Copiar" );
-		  GFAddButton( book_gump, 160, 38, 2103, 2104, GF_CLOSE_BTN, 900 + rune_pos );
-		endif
+    // Para as páginas de detalhes, mantemos o HTMLArea para permitir quebra
+    GFHTMLArea( book_gump, 160, 15, 100, 34, "<BASEFONT COLOR=#000066>" + rune_entry.name );
+    if ( TemHabilidade( who, "Escrever Pergaminhos" ) )
+      GFTextCrop( book_gump, 180, 35, 100, 18, 995, "Copiar" );
+      GFAddButton( book_gump, 160, 38, 2103, 2104, GF_CLOSE_BTN, 900 + rune_pos );
+    endif
 
-		GFTextCrop( book_gump, 170, 34, 200, 17, 995, "Esquecer" );
-		GFAddButton( book_gump, 150, 38, 2103, 2104, GF_CLOSE_BTN, 800 + rune_pos );
-		GFHTMLArea( book_gump, 140, 60, 120, 140, cstr( rune_entry.description ), 0, 1 );
+    GFTextCrop( book_gump, 140, 195, 200, 17, 995, "Esquecer" );
+    GFAddButton( book_gump, 125, 200, 2103, 2104, GF_CLOSE_BTN, 800 + rune_pos );
+    GFHTMLArea( book_gump, 140, 60, 120, 110, cstr( rune_entry.description ), 0, 1 );
 
-	  endif
-	else
-	  GenerateEmptySide( book_gump, 1, pOX, pOY, i );
-	endif
-	rune_pos := rune_pos + 1;
-	pOY := pOY + 15;
-	if ( pOY > 165 )
-	  pOY := 60;
-	  pOX := 305;
-	endif
+  endif
+else
+  GenerateEmptySide( book_gump, 1, pOX, pOY, i );
+endif
 
-	rune_entry := rune_list[rune_pos];
-	WritespellInfo( who, rune_entry );
-	rune_entry.description := "<BASEFONT COLOR=#000066>" + cstr( rune_entry.description )
-															  + "<br>" + cstr( rune_entry.flavortext ) + "<br> <BASEFONT COLOR=#330000> Componentes Materiais: <br> ";
-	regkeys := rune_entry.reagents.keys();
-	foreach r in ( regkeys )
-	  rune_entry.description := rune_entry.description + cstr( r ) + " " + cstr( rune_entry.reagents[cstr(
-															r )] ) + "<br>";
-	endforeach
-	rune_entry.description := rune_entry.description + "Mana: " + rune_entry.mana;
+rune_pos := rune_pos + 1;
+pOY := pOY + 15;
+if ( pOY > 165 )
+  pOY := 60;
+  pOX := 305;
+endif
 
-	if ( TypeOf( rune_entry ) == "Struct" )
-	  if ( rune_entry.name )
-		// This puts the rune in page 1's list.
-		GFPage( book_gump, 1 );
-		GFTextCrop( book_gump, pOX, pOY, 115, 17, 995, rune_entry.name );
-		GFPage( book_gump, i );
+rune_entry := rune_list[rune_pos];
+WritespellInfo( who, rune_entry );
+rune_entry.description := "<BASEFONT COLOR=#000066>" + cstr( rune_entry.description )
+                                            + "<br>" + cstr( rune_entry.flavortext ) + "<br> <BASEFONT COLOR=#330000> Componentes Materiais: <br> ";
+regkeys := rune_entry.reagents.keys();
+foreach r in ( regkeys )
+  rune_entry.description := rune_entry.description + cstr( r ) + " " + cstr( rune_entry.reagents[cstr(r )] ) + "<br>";
+endforeach
+rune_entry.description := rune_entry.description + "Mana: " + rune_entry.mana;
 
-		// GFHTMLArea(book_gump, 300, 15, 100, 18, rune_entry.name);
-		GFTextCrop( book_gump, 300, 15, 115, 17, 995, rune_entry.name );
-		if ( TemHabilidade( who, "Escrever Pergaminhos" ) )
-		  GFTextCrop( book_gump, 320, 35, 150, 17, 995, "Copiar" );
-		  GFAddButton( book_gump, 300, 38, 2103, 2104, GF_CLOSE_BTN, 900 + rune_pos );
-		endif
+if ( TypeOf( rune_entry ) == "Struct" )
+  if ( rune_entry.name )
+    // This puts the rune in page 1's list.
+    GFPage( book_gump, 1 );
+    GFTextCrop( book_gump, pOX, pOY, 115, 17, 995, rune_entry.name );  // Voltou para TextCrop
+    GFPage( book_gump, i );
 
-		GFTextCrop( book_gump, 320, 34, 200, 17, 995, "Esquecer" );
-		GFAddButton( book_gump, 300, 38, 2103, 2104, GF_CLOSE_BTN, 800 + rune_pos );
+    // GFHTMLArea(book_gump, 300, 15, 115, 17, rune_entry.name);
+    GFHTMLArea( book_gump, 300, 15, 115, 34, "<BASEFONT COLOR=#000066>" + rune_entry.name );
+    if ( TemHabilidade( who, "Escrever Pergaminhos" ) )
+      GFTextCrop( book_gump, 320, 35, 150, 17, 995, "Copiar" );
+      GFAddButton( book_gump, 300, 38, 2103, 2104, GF_CLOSE_BTN, 900 + rune_pos );
+    endif
 
-		GFHTMLArea( book_gump, 300, 60, 120, 140, cstr( rune_entry.description ), 0, 1 );
+    GFTextCrop( book_gump, 320, 195, 200, 17, 995, "Esquecer" );
+    GFAddButton( book_gump, 300, 200, 2103, 2104, GF_CLOSE_BTN, 800 + rune_pos );
+
+    GFHTMLArea( book_gump, 300, 60, 120, 110, cstr( rune_entry.description ), 0, 1 );
+
+
 
 	  endif
 	else

--- a/pkg/systems/spells/scrollInsert.src
+++ b/pkg/systems/spells/scrollInsert.src
@@ -48,40 +48,91 @@ endprogram
 
 
 function addScroll(who, book, rune)
-	var rune_list := GetObjProperty(book, "spells");
-	var mlore := cint( AP_GetSkill( who, MAGICLORE ) );
-	var spell_caster_slots := Cint( mlore / 5 );
+    var rune_list := GetObjProperty(book, "spells");
+    var mlore := cint( AP_GetSkill(who, MAGICLORE) );
+    var max_scrolls;
 
-	if (rune_list == error)
-		rune_list := array;
-	endif
+    // Determina o número máximo de pergaminhos baseado no tipo de personagem
+    if (GetObjProperty(who, "chardata").magia == "spellcaster")
+        // Base de 8 pergaminhos
+        max_scrolls := 8;
+        
+        // Adiciona slots extras baseado na skill
+        if (mlore >= 45)  // Começa em 45 agora
+            if (mlore >= 100)
+                max_scrolls := 16;
+            elseif (mlore >= 90)
+                max_scrolls := 15;
+            elseif (mlore >= 80)
+                max_scrolls := 14;
+            elseif (mlore >= 70)
+                max_scrolls := 13;
+            elseif (mlore >= 60)
+                max_scrolls := 12;
+            elseif (mlore >= 55)
+                max_scrolls := 11;
+            elseif (mlore >= 50)
+                max_scrolls := 10;
+            elseif (mlore >= 45)
+                max_scrolls := 9;
+            endif
+        endif
+    else
+        // Não-spellcasters têm limite fixo de 8
+        max_scrolls := 8;
+    endif
 
-	if( GetObjProperty(who, "chardata").magia == "spellcaster" && rune_list.Size() > spell_caster_slots )
-		SendSysMessage(who,"este livro ja esta cheio.");
-		MoveItemToContainer(rune, who.backpack);
-		return 0;
-	elseif( rune_list.Size() > 15 )
-		SendSysMessage(who,"este livro ja esta cheio.");
-		MoveItemToContainer(rune, who.backpack);
-		return 0;
-	endif
+    if (rune_list == error)
+        rune_list := array;
+    endif
 
-	if( !ReserveItem(rune) )
-		SendSysMessage(who,"Cancelado");
-		MoveItemToContainer(rune, who.backpack);
-		return 0;
-	endif
+    // Verificação de duplicatas
+    var new_spell := GetObjProperty(rune, "spellinfo");
+    var booktype := GetBookType(book);
 
-	Set_Critical(1);
+    foreach spell in rune_list
+        // Para livros spellcaster
+        if (booktype == "spellcaster" || spell.magic_path == "spellcaster")
+            if (spell.id == new_spell.id && spell.School == new_spell.School)
+                SendSysMessageEx(who, "Este feitico ja existe no livro!", SSM_FAIL);
+                MoveItemToContainer(rune, who.backpack);
+                return 0;
+            endif
+        // Para outros tipos de livros
+        else
+            if (spell.id == new_spell.id && spell.magic_path == new_spell.magic_path)
+                SendSysMessageEx(who, "Este feitico ja existe no livro!", SSM_FAIL);
+                MoveItemToContainer(rune, who.backpack);
+                return 0;
+            endif
+        endif
+        sleepms(2);
+    endforeach
 
-	rune_list.Append(GetObjProperty(rune, "spellinfo"));
+    // Verificação do limite de pergaminhos
+    if (rune_list.Size() >= max_scrolls)
+        SendSysMessageEx(who, "Este livro ja esta cheio.", SSM_FAIL);
+        MoveItemToContainer(rune, who.backpack);
+        return 0;
+    endif
 
-	SetObjProperty(book, "spells", rune_list);
+    if (!ReserveItem(rune))
+        SendSysMessageEx(who, "Cancelado", SSM_FAIL);
+        MoveItemToContainer(rune, who.backpack);
+        return 0;
+    endif
 
-	SendSysMessage(who, "Voce adicionou o pergaminho no livro.");
-	var e2 := ReleaseItem(rune);
-	var e := DestroyItem(rune);
-	Set_Critical(0);
+    Set_Critical(1);
+    rune_list.Append(new_spell);
+    SetObjProperty(book, "spells", rune_list);
+    
+    // Informa ao jogador quantos slots ainda estão disponíveis
+    var slots_remaining := max_scrolls - rune_list.Size();
+    SendSysMessageEx(who, "Voce adicionou o pergaminho no livro. Slots restantes: " + slots_remaining, SSM_INFO);
+    
+    ReleaseItem(rune);
+    DestroyItem(rune);
+    Set_Critical(0);
 
-	return 1;
+    return 1;
 endfunction


### PR DESCRIPTION
1 - Antes não dava pra adicionar magias repetidas, agora dá. (Não acho que seja um bug, na real faz até sentido não colocar magia repetida) - agora não dá mais para adicionar 2 pergaminhos iguais

2 - Alguns livros de magias cabem mais feitiços que outros - recriei a formula e resolvi um errinho. Agora player que não são spellcaster só poder ter 8 pergas no livro (antes era 15). E spellcaster continuam podendo ter 20, mas a progressão ficou mais linear.
Base: 8 pergaminhos (não-spellcasters e spellcasters abaixo de 45 skill)
45 skill = 9 pergaminhos
50 skill = 10 pergaminhos
55 skill = 11 pergaminhos
60 skill = 12 pergaminhos
70 skill = 13 pergaminhos
80 skill = 14 pergaminhos
90 skill = 15 pergaminhos
100 skill = 16 pergaminhos

3 - Pode acontecer do item bugar e aparecer "você não entende esse livro" - isso acontecia por que livros checam o serial dos donos. Mantive o check, mas mudei o texto pro player: "Esse livro tem dono e foi escrito de uma forma que você não entende",

4 - Dependendo do tamanho do nome da magia não dá pra ler qual feitiço é: Resolvido dentro do livro e na pagina aberta inicial. dentro do livro diminui o tamanho das caixas de texto conforme sugestão do @Digo , mudei o remover de lugar e coloquei o titulo em duas linhas.