### PR TITLE
Feat - bolsa de polvora

### DIFF
--- a/pkg/items/levers/include/efeitos.inc
+++ b/pkg/items/levers/include/efeitos.inc
@@ -102,13 +102,18 @@ endif
 			break;
 		endif
            SetObjProperty(char, "molhado", 1);
-           var itemsinbag := EnumerateItemsInContainer(char.backpack);
-            foreach item in itemsinbag
-                if (item.objtype in fire_weapons)
-                    SetObjProperty(item, "balas", 0);
-                    SendSysMessageEx(char, "A polvora da sua arma molhou!", SSM_INFO);
-                endif
-            endforeach
+var itemsinbag := EnumerateItemsInContainer(char.backpack);
+foreach item in itemsinbag
+    var container := item.container;
+    if ((item.objtype in fire_weapons || item.objtype == 0x9092) && (!container || container.objtype != 0xDE31))
+        if (item.objtype in fire_weapons)
+            SetObjProperty(item, "balas", 0);
+            SendSysMessageEx(char, "A polvora da sua arma molhou!", SSM_INFO);
+        else
+            SetObjProperty(item, "molhado", 1);
+        endif
+    endif
+endforeach
 			SetWeatherForPlayer(char, type, 50 );
 			
 				if (distance(char, item) < 20)

--- a/pkg/skills/DomesticWork/TailorMenu.cfg
+++ b/pkg/skills/DomesticWork/TailorMenu.cfg
@@ -271,6 +271,7 @@ Craftitem Miscellaneous
 	Item 		aljava 
 	Recipe 		aljavacintura 
 	Item 		Cinto do Sabio
+	Item		Bolsa de Polvora
 	Item		Buque de Flores
 	Item		Buque de Flores Ornamentais
 

--- a/pkg/skills/DomesticWork/tailoring.cfg
+++ b/pkg/skills/DomesticWork/tailoring.cfg
@@ -649,6 +649,23 @@ tailoring 0xC892
  materials cloth 5
  
 }
+
+
+domesticwork 0xDE31
+{
+    name         Bolsa de Polvora
+    skill        60
+    Graphic            0x1084 
+    difficulty   60
+    points       55
+    exceptional  1
+    mark         1
+    retain       1
+
+    principalMaterial leather
+    materials leather 8
+    materials cloth 4
+}
 //tailoring 0xFFE7
 //{
 // name     aljavacintura

--- a/pkg/skills/woodworking/canInsertPowderPouch.src
+++ b/pkg/skills/woodworking/canInsertPowderPouch.src
@@ -1,0 +1,39 @@
+use uo;
+use os;
+use cfgfile;
+
+include "include/say";
+
+program on_insert(who, bag, movetype, inserttype, item, existing_stack, amt)
+    amt            := amt;
+    existing_stack := existing_stack;
+    movetype      := movetype;
+    inserttype    := inserttype;
+    
+    var powder := 0x9092;
+    
+    if (bag.objtype == 0xDE31) // Corrigido para o novo objtype da Bolsa de Pólvora
+        if (item.objtype == powder)
+            // É pólvora, pode inserir
+        else
+            SendSysMessageEx(who, "Voce nao pode guardar isto na bolsa de polvora.", SSM_FAIL);
+            MoveItemToContainer(item, who.backpack);
+            return 0;
+        endif
+    endif
+
+    if (bag.movable == 0)
+        SendSysMessage(who, "Cancelado.");
+        MoveItemToContainer(item, who.backpack);
+        return 0;
+    elseif (!ReserveItem(bag) || !ReserveItem(item))
+        MoveItemToContainer(item, who.backpack);
+        SendSysMessage(who, "A bolsa esta em uso.");
+        return 0;
+    else
+        EraseObjProperty(item, "molhado");
+        return 1;
+    endif
+
+    return 1;
+endprogram

--- a/pkg/skills/woodworking/itemdesc.cfg
+++ b/pkg/skills/woodworking/itemdesc.cfg
@@ -449,6 +449,27 @@ RequiresAttention	1
 
 }
 
+Container 0xDE31
+{
+    Name                Bolsa de Polvora
+    desc                Bolsa de Polvora
+    
+    OnInsertScript      :woodworking:canInsertPowderPouch
+    Graphic            0x1084 
+    Color              42
+    newbie             0
+    movable            1
+    maxitems           50
+    stackable          0  // Impede que as bolsas stackem
+    
+    Gump               0x3c
+    MinX               40
+    MaxX               60
+    MinY               20
+    MaxY               80
+    
+    RequiresAttention  1
+}
 
 Container 0x3bd9
 {

--- a/pkg/systems/charactercreation/habilidades/ancestralidadeelemental.src
+++ b/pkg/systems/charactercreation/habilidades/ancestralidadeelemental.src
@@ -76,20 +76,26 @@ program controleclima(who)
         var fire_weapons := Array{0xC5FD, 0xC5FE, 0xC5FF, 0xC600, 0x89A7};
 		SetWeatherForPlayer(who, type, 50 );
 		foreach mob in enemies
-           SetObjProperty(mob, "molhado", 1);
-           var itemsinbag := EnumerateItemsInContainer(mob.backpack);
-            foreach item in itemsinbag
-                if (item.objtype in fire_weapons)
-                    SetObjProperty(item, "balas", 0);
-                    SendSysMessageEx(mob, "A polvora da sua arma molhou!", SSM_INFO);
-                endif
-            endforeach
-            foreach mob in mobs
-                if (mob in enemies)
-                else
-                    HealFLS(mob, Cint(mlore/5));
-                endif
-            endforeach
+    SetObjProperty(mob, "molhado", 1);
+    var itemsinbag := EnumerateItemsInContainer(mob.backpack);
+    foreach item in itemsinbag
+        var container := item.container;
+        if ((item.objtype in fire_weapons || item.objtype == 0x9092) && (!container || container.objtype != 0xDE31))
+            if (item.objtype in fire_weapons)
+                SetObjProperty(item, "balas", 0);
+                SendSysMessageEx(mob, "A polvora da sua arma molhou!", SSM_INFO);
+            else
+                SetObjProperty(item, "molhado", 1);
+            endif
+        endif
+    endforeach
+
+    foreach mob in mobs
+        if (mob in enemies)
+        else
+            HealFLS(mob, Cint(mlore/5));
+        endif
+    endforeach
 			SetWeatherForPlayer(mob, type, 50 );
 			if ( !(mob in who.party.members))
 				if (distance(mob, who) < 20)

--- a/pkg/systems/charactercreation/habilidades/canhoneiro.src
+++ b/pkg/systems/charactercreation/habilidades/canhoneiro.src
@@ -30,21 +30,22 @@ program vacuodemana(params)
     var has_ammo := 0;
     var has_powder := 0;
     var has_power_fixer := 0;
-    // Verificar se tem cannon ball
-    var itemsinbag := EnumerateItemsInContainer(who.backpack);
-    foreach item in itemsinbag
-        if (item.objtype == 0x4224 && !has_ammo) // cannon ball
-            has_ammo := 1;
-            subtractamount(item.objtype, 1);
-        endif
-        if (item.objtype == 0x9092 && !has_powder)
-            has_powder := 1;
-            subtractamount(item.objtype, 5);
-        endif
-        if (item.objtype == 0xC611)
-            has_power_fixer := 1;
-        endif
-    endforeach
+   // Verificar se tem cannon ball e pólvora
+var itemsinbag := EnumerateItemsInContainer(who.backpack);
+foreach item in itemsinbag
+    var container := item.container;
+    if (item.objtype == 0x4224 && !has_ammo) // cannon ball
+        has_ammo := 1;
+        subtractamount(item.objtype, 1);
+    endif
+    if (item.objtype == 0x9092 && !has_powder && (!container || container.objtype != 0xDE31))
+        has_powder := 1;
+        subtractamount(item.objtype, 5);
+    endif
+    if (item.objtype == 0xC611)
+        has_power_fixer := 1;
+    endif
+endforeach
 
     if (!has_ammo || !has_powder || !has_power_fixer)
         SendSysMessage(who, "Que artilheiro despreparado! Voce nao tem os materiais necessarios!");

--- a/pkg/systems/charactercreation/habilidades/controleclima.src
+++ b/pkg/systems/charactercreation/habilidades/controleclima.src
@@ -78,16 +78,21 @@ program controleclima(who)
 		var bolts := RandomInt(5);
         var fire_weapons := Array{0xC5FD, 0xC5FE, 0xC5FF, 0xC600, 0x89A7};
 		SetWeatherForPlayer(who, type, 50 );
-		foreach mob in enemies
-           SetObjProperty(mob, "molhado", 1);
-           var itemsinbag := EnumerateItemsInContainer(mob.backpack);
-            foreach item in itemsinbag
-                if (item.objtype in fire_weapons)
-                    SetObjProperty(item, "balas", 0);
-                    SendSysMessageEx(mob, "A polvora da sua arma molhou!", SSM_INFO);
-                endif
-            endforeach
-			SetWeatherForPlayer(mob, type, 50 );
+foreach mob in enemies
+    SetObjProperty(mob, "molhado", 1);
+    var itemsinbag := EnumerateItemsInContainer(mob.backpack);
+    foreach item in itemsinbag
+        var container := item.container;
+        if ((item.objtype in fire_weapons || item.objtype == 0x9092) && (!container || container.objtype != 0xDE31))
+            if (item.objtype in fire_weapons)
+                SetObjProperty(item, "balas", 0);
+                SendSysMessageEx(mob, "A polvora da sua arma molhou!", SSM_INFO);
+            else
+                SetObjProperty(item, "molhado", 1);
+            endif
+        endif
+    endforeach
+    SetWeatherForPlayer(mob, type, 50);
 			if ( !(mob in who.party.members))
 				if (distance(mob, who) < 20)
 					SetWeatherForPlayer(mob, type, 50 );

--- a/pkg/systems/nature/include/nature.inc
+++ b/pkg/systems/nature/include/nature.inc
@@ -155,42 +155,47 @@ endfunction
 //   254 - Unknown effect...
 
 function weathereffects(type, duration, severity := 5)
+    var i;
+    for(i := 0; i <= duration*30; i := i+1)
+        var weatherid := CStr(type);
+        var id_len := len(weatherid);
 
-	var i;
-	for(i := 0; i <= duration*30; i := i+1)
-		
-		var weatherid := CStr(type);
-		var id_len := len(weatherid);
-
-		if( id_len == 0 )
-			weatherid := "00";
-		elseif( id_len == 1)
- 			weatherid := "0" + weatherid;
- 		endif 
-	 	
-	 	var packet := "65"+weatherid+"7000";
-	 
+        if( id_len == 0 )
+            weatherid := "00";
+        elseif( id_len == 1)
+            weatherid := "0" + weatherid;
+        endif 
+        
+        var packet := "65"+weatherid+"7000";
+    
         var fire_weapons := Array{0xC5FD, 0xC5FE, 0xC5FF, 0xC600, 0x89A7};
-		foreach person in EnumerateOnlineCharacters()
+        foreach person in EnumerateOnlineCharacters()
             if (!GetObjProperty(person, "molhado"))
                 SetObjProperty(person, "molhado", 1);
             endif
             var itemsinbag := EnumerateItemsInContainer(person.backpack);
             foreach item in itemsinbag
-                if (item.objtype in fire_weapons)
-                    SetObjProperty(item, "balas", 0);
-                    SendSysMessageEx(person, "A polvora da sua arma molhou!", SSM_INFO);
+                var container := item.container;
+                if ((item.objtype in fire_weapons || item.objtype == 0x9092) && (!container || container.objtype != 0xDE31))
+                    if (item.objtype in fire_weapons)
+                        SetObjProperty(item, "balas", 0);
+                        SendSysMessageEx(person, "A polvora da sua arma molhou!", SSM_INFO);
+                    else
+                        SetObjProperty(item, "molhado", 1);
+                    endif
                 endif
             endforeach
-			if (person.x < 4174)
-				playweathersound(type, person);
-				SendPacket(person, packet);
-			endif
-		endforeach
-		
-		sleep(5);
-	endfor
-	foreach person in EnumerateOnlineCharacters()
+            
+            if (person.x < 4174)
+                playweathersound(type, person);
+                SendPacket(person, packet);
+            endif
+        endforeach
+        
+        sleep(5);
+    endfor
+    
+    foreach person in EnumerateOnlineCharacters()
         EraseObjProperty(person, "molhado");
     endforeach
 endfunction


### PR DESCRIPTION
cria uma bolsa especial que protege a pólvora de se molhar.

Funcionalidades
Bolsa de Pólvora

Objtype: 0xDE31
Graphic: 0x1084
Craftável: Através da skill DomesticWork
Requisitos:

60 Skill
8 Leather
4 Cloth


Características:

Container não stackável
Aceita apenas pólvora (0x9092)
Protege a pólvora de se molhar durante chuvas ou tempestades

Efeitos na Pólvora

Pólvora fora da bolsa de proteção fica molhada durante chuva
Armas de fogo carregadas perdem suas munições quando molhadas
Pólvora dentro da Bolsa de Pólvora permanece protegida