### PR TITLE
Fix/pcconversation

### DIFF
--- a/pkg/mobiles/merchants/pcconversation/conversation.src
+++ b/pkg/mobiles/merchants/pcconversation/conversation.src
@@ -118,7 +118,13 @@ function ConversationPlayer(who, npc, conversation)
 				element.event.y := npc.y;
 				element.event.z := npc.z;
 			endif
+			SetObjProperty(npc, "currentEvent", element.event);
 			ExecuteEvent(element.event);
+			if (element.event.type == "Abrir Passagem" || element.event.type == "Abrir Porta")
+			TS_StartTimer(npc, "events", 60);
+			else
+			    EraseObjProperty(npc, "currentEvent");
+			endif
 /*			var state := element.spawnmonster;
 	        var amt := 0;
 			while (amt < state.amount)

--- a/pkg/mobiles/timedScripts/config/timedScripts.cfg
+++ b/pkg/mobiles/timedScripts/config/timedScripts.cfg
@@ -156,6 +156,15 @@ cliloc2			1075826
 NoCure			1
 
 }
+
+TimerElem events
+{
+Name			events
+EndScript		subScripts/other/endEvent
+
+Type			U
+}
+
 #--=[ Poisons ]=------------------------------
 
 TimerElem defaultPoison

--- a/pkg/mobiles/timedScripts/subScripts/other/endEvent.src
+++ b/pkg/mobiles/timedScripts/subScripts/other/endEvent.src
@@ -1,0 +1,41 @@
+use uo;
+use os;
+use cfgfile;
+use util;
+include ":datafile:include/datafile";
+include ":tn:questevent";
+include ":merchants:pcconversation";
+
+program endEvent(params)
+    var mobile := params[1];
+    var npcelem := GetConversationDataElem(mobile.serial);
+    // Here's the issue - the evento property isn't properly accessed
+    var evento := GetObjProperty(mobile, "currentEvent");
+    
+    if (!evento)
+        return 0;
+    endif
+       
+    if (evento.type == "Abrir Porta" )
+        foreach serial in (evento.items)
+            var item := SystemFindObjectBySerial(serial);
+            item.locked := 1;
+        endforeach
+    elseif (evento.type == "Abrir Passagem")
+        var i := 0;
+        while ( i < 20)
+            foreach serial in (evento.items)
+                var item := SystemFindObjectBySerial(serial);
+                item.movable := 1;
+                MoveObjectToLocation(item, item.x, item.y, item.z - 1, item.realm, MOVEOBJECT_FORCELOCATION);
+                item.movable := 0;
+            endforeach
+            i := i + 1;
+        endwhile
+    endif
+    
+    // Clear the current event
+    EraseObjProperty(mobile, "currentEvent");
+    
+    return 1;
+endprogram


### PR DESCRIPTION
Corrigido o tempo de restart dos eventos triggados pelo npc conversation com a opção "fazer eventos". Foi criado um TimedScript para isso "events"